### PR TITLE
add forced waiting for the next element in the workflow

### DIFF
--- a/workflows/workflow_use/builder/service.py
+++ b/workflows/workflow_use/builder/service.py
@@ -319,6 +319,27 @@ class BuilderService:
             )
             raise  # Re-raise other unexpected errors
 
+        # New logic: Add next_step_selector to each step
+        if workflow_data.steps:
+            for i in range(len(workflow_data.steps) - 1):  # Exclude the last step
+                current_step = workflow_data.steps[i]
+                next_step = workflow_data.steps[i + 1]
+
+                # Extract the CSS selector from the next step
+                next_selector = None
+                if getattr(next_step, "type", None) in ["click", "input", "select_change", "key_press"]:
+                    next_selector = getattr(next_step, "cssSelector", None)
+
+                if next_selector:
+                    setattr(current_step, "waitForElement", next_selector)
+                    logger.debug(
+                        f"Set waitForElement '{next_selector}' for step {i} (type: {getattr(current_step, 'type', None)})."
+                    )
+                else:
+                    logger.debug(
+                        f"Skipped waitForElement for step {i} (next step type: {getattr(next_step, 'type', None)}, cssSelector: {getattr(next_step, 'cssSelector', None)})."
+                    )
+
         # Return the workflow data object directly
         return workflow_data
 

--- a/workflows/workflow_use/controller/service.py
+++ b/workflows/workflow_use/controller/service.py
@@ -5,7 +5,7 @@ from browser_use.agent.views import ActionResult
 from browser_use.browser.context import BrowserContext
 from browser_use.controller.service import Controller
 
-from workflow_use.controller.utils import get_best_element_handle
+from workflow_use.controller.utils import get_best_element_handle, wait_for_element
 from workflow_use.controller.views import (
     ClickElementDeterministicAction,
     InputTextDeterministicAction,
@@ -67,6 +67,20 @@ class WorkflowController(Controller):
             await page.goto(params.url)
             await page.wait_for_load_state()
 
+            # Wait for waitForElement if present
+            if hasattr(params, "waitForElement") and params.waitForElement:
+                try:
+                    await wait_for_element(
+                        page,
+                        params.waitForElement,
+                        # params,
+                        timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
+                    )
+                except Exception as e:
+                    error_msg = f"Failed to wait for element after navigation. Selector: {params.waitForElement}. Error: {str(e)}"
+                    logger.error(error_msg)
+                    raise Exception(error_msg)
+
             msg = f"🔗  Navigated to URL: {params.url}"
             logger.info(msg)
             return ActionResult(extracted_content=msg, include_in_memory=True)
@@ -92,6 +106,15 @@ class WorkflowController(Controller):
                     timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
                 )
                 await locator.click(force=True)
+
+                # Wait for waitForElement if present
+                if hasattr(params, "waitForElement") and params.waitForElement:
+                    await wait_for_element(
+                        page,
+                        params.waitForElement,
+                        # params,
+                        timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
+                    )
 
                 msg = f"🖱️  Clicked element with CSS selector: {selector_used} (original: {original_selector})"
                 logger.info(msg)
@@ -137,6 +160,15 @@ class WorkflowController(Controller):
                 await locator.click(force=True)
                 await asyncio.sleep(0.5)
 
+                # Wait for waitForElement if present
+                if hasattr(params, "waitForElement") and params.waitForElement:
+                    await wait_for_element(
+                        page,
+                        params.waitForElement,
+                        # params,
+                        timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
+                    )
+
                 msg = f'⌨️  Input "{params.value}" into element with CSS selector: {selector_used} (original: {original_selector})'
                 logger.info(msg)
                 return ActionResult(extracted_content=msg, include_in_memory=True)
@@ -167,6 +199,15 @@ class WorkflowController(Controller):
 
                 await locator.select_option(label=params.selectedText)
 
+                # Wait for waitForElement if present
+                if hasattr(params, "waitForElement") and params.waitForElement:
+                    await wait_for_element(
+                        page,
+                        params.waitForElement,
+                        # params,
+                        timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
+                    )
+
                 msg = f'Selected option "{params.selectedText}" in dropdown {selector_used} (original: {original_selector})'
                 logger.info(msg)
                 return ActionResult(extracted_content=msg, include_in_memory=True)
@@ -193,6 +234,15 @@ class WorkflowController(Controller):
                 )
 
                 await locator.press(params.key)
+
+                # Wait for waitForElement if present
+                if hasattr(params, "waitForElement") and params.waitForElement:
+                    await wait_for_element(
+                        page,
+                        params.waitForElement,
+                        # params,
+                        timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
+                    )
 
                 msg = f"🔑  Pressed key '{params.key}' on element with CSS selector: {selector_used} (original: {original_selector})"
                 logger.info(msg)

--- a/workflows/workflow_use/controller/service.py
+++ b/workflows/workflow_use/controller/service.py
@@ -18,6 +18,7 @@ from workflow_use.controller.views import (
 logger = logging.getLogger(__name__)
 
 DEFAULT_ACTION_TIMEOUT_MS = 1000
+DEFAULT_WAIT_FOR_ELEMENT_TIMEOUT_MS = 3000
 
 # List of default actions from browser_use.controller.service.Controller to disable
 # todo: come up with a better way to filter out the actions (filter IN the actions would be much nicer in this case)
@@ -74,7 +75,7 @@ class WorkflowController(Controller):
                         page,
                         params.waitForElement,
                         # params,
-                        timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
+                        timeout_ms=DEFAULT_WAIT_FOR_ELEMENT_TIMEOUT_MS,
                     )
                 except Exception as e:
                     error_msg = f"Failed to wait for element after navigation. Selector: {params.waitForElement}. Error: {str(e)}"
@@ -113,7 +114,7 @@ class WorkflowController(Controller):
                         page,
                         params.waitForElement,
                         # params,
-                        timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
+                        timeout_ms=DEFAULT_WAIT_FOR_ELEMENT_TIMEOUT_MS,
                     )
 
                 msg = f"🖱️  Clicked element with CSS selector: {selector_used} (original: {original_selector})"
@@ -166,7 +167,7 @@ class WorkflowController(Controller):
                         page,
                         params.waitForElement,
                         # params,
-                        timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
+                        timeout_ms=DEFAULT_WAIT_FOR_ELEMENT_TIMEOUT_MS,
                     )
 
                 msg = f'⌨️  Input "{params.value}" into element with CSS selector: {selector_used} (original: {original_selector})'
@@ -205,7 +206,7 @@ class WorkflowController(Controller):
                         page,
                         params.waitForElement,
                         # params,
-                        timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
+                        timeout_ms=DEFAULT_WAIT_FOR_ELEMENT_TIMEOUT_MS,
                     )
 
                 msg = f'Selected option "{params.selectedText}" in dropdown {selector_used} (original: {original_selector})'
@@ -241,7 +242,7 @@ class WorkflowController(Controller):
                         page,
                         params.waitForElement,
                         # params,
-                        timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
+                        timeout_ms=DEFAULT_WAIT_FOR_ELEMENT_TIMEOUT_MS,
                     )
 
                 msg = f"🔑  Pressed key '{params.key}' on element with CSS selector: {selector_used} (original: {original_selector})"

--- a/workflows/workflow_use/controller/utils.py
+++ b/workflows/workflow_use/controller/utils.py
@@ -1,4 +1,7 @@
 import re
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 async def get_best_element_handle(page, selector, params=None, timeout_ms=500):
@@ -13,13 +16,13 @@ async def get_best_element_handle(page, selector, params=None, timeout_ms=500):
 
     for try_selector in selectors_to_try:
         try:
-            print(f"Trying selector: {try_selector}")
+            logger.info(f"Trying selector: {try_selector}")
             locator = page.locator(try_selector)
             await locator.wait_for(state="visible", timeout=timeout_ms)
-            print(f"Found element with selector: {try_selector}")
+            logger.info(f"Found element with selector: {try_selector}")
             return locator, try_selector
         except Exception as e:
-            print(f"Selector failed: {try_selector} with error: {e}")
+            logger.error(f"Selector failed: {try_selector} with error: {e}")
 
     # Try XPath as last resort
     if params and getattr(params, "xpath", None):
@@ -30,25 +33,25 @@ async def get_best_element_handle(page, selector, params=None, timeout_ms=500):
 
             for try_xpath in xpath_alternatives:
                 xpath_selector = f"xpath={try_xpath}"
-                print(f"Trying XPath: {xpath_selector}")
+                logger.info(f"Trying XPath: {xpath_selector}")
                 locator = page.locator(xpath_selector)
                 await locator.wait_for(state="visible", timeout=timeout_ms)
                 return locator, xpath_selector
         except Exception as e:
-            print(f"All XPaths failed with error: {e}")
+            logger.error(f"All XPaths failed with error: {e}")
 
     raise Exception(f"Failed to find element. Original: {original_selector}")
 
 async def wait_for_element(page, selector, timeout_ms=1000):
     """Wait for an element to be visible using the provided CSS selector."""
     try:
-        print(f"Starting wait for element with selector: {selector}")
+        logger.info(f"Starting wait for element with selector: {selector}")
         locator = page.locator(selector)
         await locator.wait_for(state="visible", timeout=timeout_ms)
-        print(f"Waited for element with selector: {selector}")
+        logger.info(f"Waited for element with selector: {selector}")
         return selector
     except Exception as e:
-        print(f"Failed to wait for element with selector: {selector}. Error: {e}")
+        logger.error(f"Failed to wait for element with selector: {selector}. Error: {e}")
         raise Exception(f"Failed to wait for element. Selector: {selector}")
 
 

--- a/workflows/workflow_use/controller/utils.py
+++ b/workflows/workflow_use/controller/utils.py
@@ -39,6 +39,18 @@ async def get_best_element_handle(page, selector, params=None, timeout_ms=500):
 
     raise Exception(f"Failed to find element. Original: {original_selector}")
 
+async def wait_for_element(page, selector, timeout_ms=1000):
+    """Wait for an element to be visible using the provided CSS selector."""
+    try:
+        print(f"Starting wait for element with selector: {selector}")
+        locator = page.locator(selector)
+        await locator.wait_for(state="visible", timeout=timeout_ms)
+        print(f"Waited for element with selector: {selector}")
+        return selector
+    except Exception as e:
+        print(f"Failed to wait for element with selector: {selector}. Error: {e}")
+        raise Exception(f"Failed to wait for element. Selector: {selector}")
+
 
 def generate_stable_selectors(selector, params=None):
     """Generate selectors from most to least stable based on selector patterns."""

--- a/workflows/workflow_use/controller/views.py
+++ b/workflows/workflow_use/controller/views.py
@@ -24,6 +24,7 @@ class RecorderBase(StepMeta):
     elementText: Optional[str] = None
     frameUrl: Optional[str] = None
     screenshot: Optional[str] = None
+    waitForElement: Optional[str] = None
 
 
 class ClickElementDeterministicAction(RecorderBase):
@@ -63,6 +64,7 @@ class NavigationAction(_BaseExtra):
 
     type: Literal["navigation"]
     url: str
+    waitForElement: Optional[str] = None
 
 
 class ScrollDeterministicAction(_BaseExtra):

--- a/workflows/workflow_use/schema/views.py
+++ b/workflows/workflow_use/schema/views.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 class BaseWorkflowStep(BaseModel):
 	description: Optional[str] = Field(None, description="Optional description/comment about the step's purpose.")
 	output: Optional[str] = Field(None, description='Context key to store step output under.')
+	waitForElement: Optional[str] = Field(None, description='Element to wait for before executing the step.')
 	# Allow other fields captured from raw events but not explicitly modeled
 	model_config = {'extra': 'allow'}
 

--- a/workflows/workflow_use/workflow/service.py
+++ b/workflows/workflow_use/workflow/service.py
@@ -201,6 +201,7 @@ class Workflow:
 			max_steps=5,
 			output=None,
 			description='Fallback agent to handle step failure',
+			waitForElement=None
 		)
 
 		return await self._run_agent_step(agent_step_config)


### PR DESCRIPTION
most of the steps have an additional attribute waitForElement which is just the next steps cssSelector. in the controller before the action can be sent as successful back to the executor it has to wait for the next element to be visible. this makes the agent fallback like at least 3x more efficient at finding the right spot where the execution failed, with minor drawbacks.

Next goal is to try to limit the agent fallback so that it doesn't wander off too far and trying to restrict the its resources as effectively as possible.