### PR TITLE
Highlighting feature

### DIFF
--- a/extension/src/components/ui/button.tsx
+++ b/extension/src/components/ui/button.tsx
@@ -57,3 +57,40 @@ function Button({
 }
 
 export { Button, buttonVariants };
+
+interface ToggleButtonProps extends React.ComponentProps<typeof Button> {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  onLabel?: string;
+  offLabel?: string;
+}
+
+function ToggleButton({
+  checked,
+  onCheckedChange,
+  onLabel = "On",
+  offLabel = "Off",
+  className,
+  variant,
+  size = "sm",
+  ...props
+}: ToggleButtonProps) {
+  const handleClick = () => {
+    onCheckedChange(!checked);
+  };
+
+  return (
+    <Button
+      variant={checked ? "default" : "secondary"} // Green for on, gray for off
+      size={size}
+      onClick={handleClick}
+      className={cn("min-w-[60px] justify-center", className)} // Ensure minimum width
+      aria-pressed={checked}
+      {...props}
+    >
+      {checked ? onLabel : offLabel}
+    </Button>
+  );
+}
+
+export { ToggleButton };

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -206,6 +206,8 @@ function startRecorder() {
   document.addEventListener('input', handleInput, true);
   document.addEventListener('change', handleSelectChange, true);
   document.addEventListener('keydown', handleKeydown, true);
+  document.addEventListener('mouseover', handleMouseOver, true);
+  document.addEventListener('mouseout', handleMouseOut, true);
   console.log('Permanently attached custom event listeners.');
 }
 
@@ -221,6 +223,8 @@ function stopRecorder() {
     document.removeEventListener('input', handleInput, true);
     document.removeEventListener('change', handleSelectChange, true); // Remove change listener
     document.removeEventListener('keydown', handleKeydown, true); // Remove keydown listener
+    document.removeEventListener('mouseover', handleMouseOver, true);
+    document.removeEventListener('mouseout', handleMouseOut, true);
   } else {
     console.log('Recorder not running, cannot stop.');
   }
@@ -391,6 +395,66 @@ function handleKeydown(event: KeyboardEvent) {
 }
 // --- End Custom Keydown Handler ---
 
+// Store the current overlay to manage its lifecycle
+let currentOverlay: HTMLDivElement | null = null;
+
+// Handle mouseover to create overlay
+function handleMouseOver(event: MouseEvent) {
+  if (!isRecordingActive) return;
+  const targetElement = event.target as HTMLElement;
+  if (!targetElement) return;
+
+  // Remove any existing overlay to avoid duplicates
+  if (currentOverlay) {
+    // console.log('Removing existing overlay');
+    currentOverlay.remove();
+    currentOverlay = null;
+  }
+
+  try {
+    const xpath = getXPath(targetElement);
+    // console.log('XPath of target element:', xpath);
+    const elementToHighlight = document.evaluate(
+      xpath,
+      document,
+      null,
+      XPathResult.FIRST_ORDERED_NODE_TYPE,
+      null
+    ).singleNodeValue as HTMLElement;
+    if (elementToHighlight) {
+      const rect = elementToHighlight.getBoundingClientRect();
+      const highlightOverlay = document.createElement('div');
+      highlightOverlay.className = 'highlight-overlay';
+      Object.assign(highlightOverlay.style, {
+        position: 'absolute',
+        top: `${rect.top + window.scrollY}px`,
+        left: `${rect.left + window.scrollX}px`,
+        width: `${rect.width}px`,
+        height: `${rect.height}px`,
+        border: '2px solid lightgreen',
+        backgroundColor: 'rgba(144, 238, 144, 0.2)', // lightgreen tint
+        pointerEvents: 'none',
+        zIndex: '2147483000',
+      });
+      document.body.appendChild(highlightOverlay);
+      currentOverlay = highlightOverlay;
+    } else {
+      console.warn('No element found to highlight for xpath:', xpath);
+    }
+  } catch (error) {
+    console.error('Error creating highlight overlay:', error);
+  }
+}
+
+// Handle mouseout to remove overlay
+function handleMouseOut(event: MouseEvent) {
+  if (!isRecordingActive) return;
+  if (currentOverlay) {
+    currentOverlay.remove();
+    currentOverlay = null;
+  }
+}
+
 export default defineContentScript({
   matches: ['<all_urls>'],
   main(ctx) {
@@ -443,6 +507,8 @@ export default defineContentScript({
       document.removeEventListener('input', handleInput, true);
       document.removeEventListener('change', handleSelectChange, true);
       document.removeEventListener('keydown', handleKeydown, true);
+      document.removeEventListener('mouseover', handleMouseOver, true);
+      document.removeEventListener('mouseout', handleMouseOut, true);
       stopRecorder(); // Ensure rrweb is stopped
     });
 

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -414,13 +414,32 @@ function handleMouseOver(event: MouseEvent) {
   try {
     const xpath = getXPath(targetElement);
     // console.log('XPath of target element:', xpath);
-    const elementToHighlight = document.evaluate(
+    let elementToHighlight: HTMLElement | null = document.evaluate(
       xpath,
       document,
       null,
       XPathResult.FIRST_ORDERED_NODE_TYPE,
       null
-    ).singleNodeValue as HTMLElement;
+    ).singleNodeValue as HTMLElement | null;
+    if (!elementToHighlight) {
+      const enhancedSelector = getEnhancedCSSSelector(targetElement, xpath);
+      console.log('CSS Selector:', enhancedSelector);
+      const elements = document.querySelectorAll<HTMLElement>(enhancedSelector);
+
+      // Try to find the element under the mouse
+      for (const el of elements) {
+        const rect = el.getBoundingClientRect();
+        if (
+          event.clientX >= rect.left &&
+          event.clientX <= rect.right &&
+          event.clientY >= rect.top &&
+          event.clientY <= rect.bottom
+        ) {
+          elementToHighlight = el;
+          break;
+        }
+      }
+    }
     if (elementToHighlight) {
       const rect = elementToHighlight.getBoundingClientRect();
       const highlightOverlay = document.createElement('div');

--- a/extension/src/entrypoints/sidepanel/components/recording-view.tsx
+++ b/extension/src/entrypoints/sidepanel/components/recording-view.tsx
@@ -1,11 +1,26 @@
-import React from "react";
+import React, { useState } from "react";
 import { useWorkflow } from "../context/workflow-provider";
 import { Button } from "@/components/ui/button";
+import { ToggleButton } from "@/components/ui/button";
 import { EventViewer } from "./event-viewer"; // Import EventViewer
 
 export const RecordingView: React.FC = () => {
-  const { stopRecording, workflow } = useWorkflow();
+  const {
+    stopRecording,
+    workflow,
+    stopHighlighting,
+    startHighlighting,
+    highlightingStatus,
+  } = useWorkflow();
   const stepCount = workflow?.steps?.length || 0;
+
+  const toggleHighlighting = () => {
+    if (highlightingStatus === "highlighting_enabled") {
+      stopHighlighting();
+    } else {
+      startHighlighting();
+    }
+  };
 
   return (
     <div className="flex flex-col h-full">
@@ -19,6 +34,13 @@ export const RecordingView: React.FC = () => {
             Recording ({stepCount} steps)
           </span>
         </div>
+        <ToggleButton
+          checked={highlightingStatus === "highlighting_enabled"}
+          onCheckedChange={toggleHighlighting}
+          onLabel="Highlight On"
+          offLabel="Highlight Off"
+          aria-label="Toggle highlighting"
+        />
         <Button variant="destructive" size="sm" onClick={stopRecording}>
           Stop Recording
         </Button>

--- a/extension/src/entrypoints/sidepanel/context/workflow-provider.tsx
+++ b/extension/src/entrypoints/sidepanel/context/workflow-provider.tsx
@@ -172,7 +172,7 @@ export const WorkflowProvider: React.FC<WorkflowProviderProps> = ({
     };
     // Keep dependencies: fetchWorkflowData is stable now,
     // recordingStatus dependency correctly handles interval setup/teardown.
-  }, [fetchWorkflowData, recordingStatus, highlightingStatus]);
+  }, [fetchWorkflowData, recordingStatus]);
 
   // startRecording, stopRecording, discardAndStartNew, selectEvent remain largely the same
   // but ensure isLoading is handled appropriately

--- a/extension/src/entrypoints/sidepanel/context/workflow-provider.tsx
+++ b/extension/src/entrypoints/sidepanel/context/workflow-provider.tsx
@@ -11,6 +11,7 @@ import { Workflow } from "../../../lib/workflow-types"; // Adjust path as needed
 type WorkflowState = {
   workflow: Workflow | null;
   recordingStatus: string; // e.g., 'idle', 'recording', 'stopped', 'error'
+  highlightingStatus: string; // e.g., 'highlighting_enabled', 'highlighting_disabled'
   currentEventIndex: number;
   isLoading: boolean;
   error: string | null;
@@ -22,6 +23,8 @@ type WorkflowContextType = WorkflowState & {
   discardAndStartNew: () => void;
   selectEvent: (index: number) => void;
   fetchWorkflowData: (isPolling?: boolean) => void; // Add optional flag
+  startHighlighting: () => void;
+  stopHighlighting: () => void;
 };
 
 const WorkflowContext = createContext<WorkflowContextType | undefined>(
@@ -39,6 +42,9 @@ export const WorkflowProvider: React.FC<WorkflowProviderProps> = ({
 }) => {
   const [workflow, setWorkflow] = useState<Workflow | null>(null);
   const [recordingStatus, setRecordingStatus] = useState<string>("idle"); // 'idle', 'recording', 'stopped', 'error'
+  const [highlightingStatus, setHighlightingStatus] = useState<string>(
+    "highlighting_disabled"
+  ); // 'highlighting_enabled', 'highlighting_disabled'
   const [currentEventIndex, setCurrentEventIndex] = useState<number>(0);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -130,6 +136,16 @@ export const WorkflowProvider: React.FC<WorkflowProviderProps> = ({
           }
           return newStatus; // Return the new status to update the state
         });
+      } else if (message.type === "highlighting_status_updated") {
+        console.log(
+          "Highlighting status updated message received:",
+          message.payload
+        );
+        const newStatus = message.payload.status;
+        // Use functional update to get previous status reliably
+        setHighlightingStatus((prevStatus) => {
+          return newStatus; // Return the new status to update the state
+        });
       }
     };
     chrome.runtime.onMessage.addListener(messageListener);
@@ -156,7 +172,7 @@ export const WorkflowProvider: React.FC<WorkflowProviderProps> = ({
     };
     // Keep dependencies: fetchWorkflowData is stable now,
     // recordingStatus dependency correctly handles interval setup/teardown.
-  }, [fetchWorkflowData, recordingStatus]);
+  }, [fetchWorkflowData, recordingStatus, highlightingStatus]);
 
   // startRecording, stopRecording, discardAndStartNew, selectEvent remain largely the same
   // but ensure isLoading is handled appropriately
@@ -200,6 +216,36 @@ export const WorkflowProvider: React.FC<WorkflowProviderProps> = ({
     });
   }, []); // No dependencies needed
 
+  const startHighlighting = useCallback(() => {
+    setError(null);
+    chrome.runtime.sendMessage({ type: "START_HIGHLIGHTING" }, (response) => {
+      if (chrome.runtime.lastError) {
+        console.error("Error starting highlighting:", chrome.runtime.lastError);
+        setError(
+          `Failed to start highlighting: ${chrome.runtime.lastError.message}`
+        );
+      } else {
+        console.log("Start highlighting acknowledged by background.");
+        // State updates happen via broadcast + fetch
+      }
+    });
+  }, []);
+
+  const stopHighlighting = useCallback(() => {
+    setError(null);
+    chrome.runtime.sendMessage({ type: "STOP_HIGHLIGHTING" }, (response) => {
+      if (chrome.runtime.lastError) {
+        console.error("Error stopping highlighting:", chrome.runtime.lastError);
+        setError(
+          `Failed to stop highlighting: ${chrome.runtime.lastError.message}`
+        );
+      } else {
+        console.log("Stop highlighting acknowledged by background.");
+        // State updates happen via broadcast + fetch
+      }
+    });
+  }, []);
+
   const discardAndStartNew = useCallback(() => {
     startRecording();
   }, [startRecording]);
@@ -211,6 +257,7 @@ export const WorkflowProvider: React.FC<WorkflowProviderProps> = ({
   const value = {
     workflow,
     recordingStatus,
+    highlightingStatus,
     currentEventIndex,
     isLoading,
     error,
@@ -219,6 +266,8 @@ export const WorkflowProvider: React.FC<WorkflowProviderProps> = ({
     discardAndStartNew,
     selectEvent,
     fetchWorkflowData,
+    startHighlighting,
+    stopHighlighting,
   };
 
   return (


### PR DESCRIPTION
I'll open this PR as a draft since there is still a bug. Will get back to it when I get the idea on how to fix it. Here is a quick description.

A toggle button was added in RecordingView.tsx next to the "Stop Recording" button, allowing users to enable/disable highlighting. The feature leverages the WorkflowContext in workflow-provider.tsx to manage state and communicate with the background script (background.ts) via messages like START_HIGHLIGHTING and STOP_HIGHLIGHTING. While the highlighting works as expected when manually triggered, the toggle button consistently throws a Chrome runtime error: "The message port was closed before a response was received". I suspect the issue lies in the useEffect hook or state management within workflow-provider.tsx, possibly due to the lifecycle of the message listener. 

Changes Made:
In workflow-provider.tsx, I added highlightingStatus to the context, implemented startHighlighting and stopHighlighting methods, and updated the useEffect hook to listen for highlighting_status_updated messages. In background.ts, I added broadcastHighlightingStatus to notify the side panel. content.ts was updated to handle SET_HIGHLIGHTING_STATUS, and RecordingView.tsx now includes a ToggleButton component (added in button.tsx) for the toggle UI. To debug, check the side panel console (right-click → Inspect) for missing logs (e.g., “Start highlighting acknowledged by background”) and the background console (chrome://extensions/ → “inspect views”) for “Received START_HIGHLIGHTING request.” 