### PR TITLE
Process JSON files using UTF-8 encoding.

### DIFF
--- a/workflows/workflow_use/builder/service.py
+++ b/workflows/workflow_use/builder/service.py
@@ -327,7 +327,7 @@ class BuilderService:
         self, path: Path, user_goal: str
     ) -> WorkflowDefinitionSchema:
         """Build a workflow from a JSON file path."""
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8") as f:
             workflow_data = json.load(f)
 
         workflow_data_schema = WorkflowDefinitionSchema.model_validate(workflow_data)
@@ -337,5 +337,5 @@ class BuilderService:
         self, workflow: WorkflowDefinitionSchema, path: Path
     ):
         """Save a workflow to a JSON file path."""
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             json.dump(workflow.model_dump(mode="json"), f, indent=2)


### PR DESCRIPTION
Use UTF-8 encoding for workflow JSON to ensure robustness, especially when handling Chinese characters that might otherwise cause errors.
#23 