### PR TITLE
Workflow Metadata Handling Refactoring

### DIFF
--- a/ui/src/components/play-button.tsx
+++ b/ui/src/components/play-button.tsx
@@ -4,7 +4,7 @@ import { PlayButtonProps, InputField } from "../types/play-button.types";
 
 export const PlayButton: React.FC<PlayButtonProps> = ({
   workflowName,
-  workflowMetadata,
+  workflowData
 }) => {
   const [showModal, setShowModal] = useState<boolean>(false);
   const [showLogViewer, setShowLogViewer] = useState<boolean>(false);
@@ -15,14 +15,15 @@ export const PlayButton: React.FC<PlayButtonProps> = ({
   const [logPosition, setLogPosition] = useState<number>(0);
   const [workflowStatus, setWorkflowStatus] = useState<string>("idle");
 
+  const inputSchema = workflowData?.input_schema;
   const openModal = () => {
     if (!workflowName) return;
 
     setShowModal(true);
     setError(null);
 
-    if (workflowMetadata && workflowMetadata.input_schema) {
-      const fields = workflowMetadata.input_schema.map((input: any) => ({
+    if (inputSchema) {
+      const fields = inputSchema.map((input: any) => ({
         name: input.name,
         type: input.type,
         required: input.required,
@@ -157,7 +158,7 @@ export const PlayButton: React.FC<PlayButtonProps> = ({
             {/* header */}
             <div className="flex items-center justify-between border-b border-gray-700 p-4">
               <h3 className="m-0 text-lg">
-                Execute Workflow: {workflowMetadata?.name || workflowName}
+                Execute Workflow: {workflowName}
               </h3>
               <button
                 onClick={closeModal}

--- a/ui/src/components/sidebar.tsx
+++ b/ui/src/components/sidebar.tsx
@@ -1,23 +1,12 @@
 import React from "react";
 import WorkflowItem from "./workflow-item";
-import { WorkflowMetadata } from "../types/workflow-layout.types";
-
-interface SidebarProps {
-  workflows: string[];
-  onSelect: (workflow: string) => void;
-  selected: string | null;
-  workflowMetadata: WorkflowMetadata | null;
-  onUpdateMetadata: (metadata: WorkflowMetadata) => Promise<void>;
-  allWorkflowsMetadata?: Record<string, WorkflowMetadata>;
-}
+import { SidebarProps } from "../types/sidebar.types";
 
 export const Sidebar: React.FC<SidebarProps> = ({
-  workflows,
   onSelect,
   selected,
-  workflowMetadata,
-  onUpdateMetadata,
-  allWorkflowsMetadata = {},
+  workflowsData,
+  onUpdateWorkflow,
 }) => (
   <aside className="w-[250px] border-r border-[#542e2e] p-3 bg-[#2a2a2a] text-white flex flex-col overflow-auto">
     {/* logo */}
@@ -32,18 +21,14 @@ export const Sidebar: React.FC<SidebarProps> = ({
     <h3 className="text-lg text-[#ddd]">Workflows</h3>
 
     <ul className="m-0 p-0">
-      {workflows.map((id) => (
+      {Object.keys(workflowsData).map((id) => (
         <WorkflowItem
           key={id}
           id={id}
           selected={id === selected}
-          metadata={
-            id === selected
-              ? workflowMetadata ?? undefined
-              : allWorkflowsMetadata[id]
-          }
+          workflow={workflowsData[id]}
           onSelect={onSelect}
-          onUpdateMetadata={onUpdateMetadata}
+          onUpdateWorkflow={(workflow) => onUpdateWorkflow(id, workflow)}
         />
       ))}
     </ul>

--- a/ui/src/components/workflow-item.tsx
+++ b/ui/src/components/workflow-item.tsx
@@ -1,56 +1,52 @@
 import React, { useState, ChangeEvent } from "react";
 import {
-  WorkflowMetadata,
+  Workflow,
   WorkflowItemProps,
 } from "../types/workflow-layout.types";
 
 const WorkflowItem: React.FC<WorkflowItemProps> = ({
   id,
   selected,
-  metadata,
+  workflow,
   onSelect,
-  onUpdateMetadata,
+  onUpdateWorkflow,
 }) => {
   const [isEditing, setIsEditing] = useState(false);
-  const [edited, setEdited] = useState<WorkflowMetadata | null>(null);
+  const [edited, setEdited] = useState<Workflow | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const displayName = () => {
-    if (metadata)
+    if (workflow)
       return (
         <>
-          <span className="text-md">{metadata.name}</span>
-          {metadata.version && (
+          <span className="text-md">{workflow.name}</span>
+          {workflow.version && (
             <span className="text-xs text-[#888] ml-1.5">
-              v{metadata.version}
+              v{workflow.version}
             </span>
           )}
         </>
       );
-
-    return (
-      <span className="text-[#ccc]">
-        <span className="opacity-70">Loading workflow…</span>
-        <span className="hidden">{id}</span>
-      </span>
-    );
+    return <span className="text-md">{id}</span>;
   };
 
-  const change =
-    (field: keyof WorkflowMetadata) =>
-    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
-      edited && setEdited({ ...edited, [field]: e.target.value });
+  const change = 
+    (field: keyof Workflow) => 
+    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      if (!edited) return;
+      setEdited({ ...edited, [field]: e.target.value });
+    };
 
   const save = async () => {
     if (!edited) return;
     setSubmitting(true);
-    await onUpdateMetadata(edited).finally(() => setSubmitting(false));
+    await onUpdateWorkflow(edited).finally(() => setSubmitting(false));
     setIsEditing(false);
   };
 
-  const editForm = metadata && (
+  const editForm = workflow && (
     <div>
-      {(["name", "version"] as (keyof WorkflowMetadata)[]).map((f) => (
+      {(["name", "version"] as const).map((f) => (
         <label key={f} className="block text-xs mb-2">
           <span className="block text-[#aaa] mb-1">
             {f[0]?.toUpperCase() + f.slice(1)}
@@ -58,7 +54,7 @@ const WorkflowItem: React.FC<WorkflowItemProps> = ({
           <input
             className="w-full bg-[#333] border border-[#555] text-white p-1.5 rounded text-xs"
             value={edited?.[f] ?? ""}
-            onChange={change(f)}
+            onChange={change(f as keyof Workflow)}
           />
         </label>
       ))}
@@ -92,18 +88,18 @@ const WorkflowItem: React.FC<WorkflowItemProps> = ({
     </div>
   );
 
-  const readOnly = metadata && (
+  const readOnly = workflow && (
     <>
       <div className="mb-2">
         <div className="text-xs text-[#aaa] mb-1">Description</div>
-        <div className="text-xs">{metadata.description}</div>
+        <div className="text-xs">{workflow.description}</div>
       </div>
 
-      {metadata.input_schema?.length && (
+      {Array.isArray(workflow.input_schema) && workflow.input_schema.length > 0 && (
         <>
           <div className="text-xs text-[#aaa] mb-1">Input Parameters</div>
           <ul className="pl-4 text-xs list-disc marker:text-[#7ac5ff]">
-            {metadata.input_schema.map((p) => (
+            {workflow.input_schema.map((p) => (
               <li key={p.name} className="mb-1">
                 <span className="text-[#7ac5ff]">{p.name}</span>
                 <span className="text-[#aaa]"> ({p.type})</span>
@@ -131,14 +127,14 @@ const WorkflowItem: React.FC<WorkflowItemProps> = ({
       </li>
 
       {/* details panel */}
-      {selected && metadata && (
+      {selected && workflow && (
         <li className="py-2 pl-4 border-l border-[#444] my-1 ml-1">
           <div className="flex justify-between items-center mb-2">
             <h4 className="m-0 text-sm text-[#ddd]">Details</h4>
             {!isEditing && (
               <button
                 onClick={() => {
-                  setEdited({ ...metadata });
+                  setEdited({ ...workflow });
                   setIsEditing(true);
                 }}
                 className="bg-[#444] text-white py-1 px-2 rounded text-xs"

--- a/ui/src/types/play-button.types.ts
+++ b/ui/src/types/play-button.types.ts
@@ -1,8 +1,8 @@
-import { WorkflowMetadata } from './workflow-layout.types';
+import { Workflow } from './workflow-layout.types';
 
 export interface PlayButtonProps {
   workflowName: string | null;
-  workflowMetadata: WorkflowMetadata | null;
+  workflowData: Workflow | null;
 }
 
 export interface InputField {

--- a/ui/src/types/sidebar.types.ts
+++ b/ui/src/types/sidebar.types.ts
@@ -1,10 +1,8 @@
-import { type WorkflowMetadata } from './workflow-layout.types';
+import { Workflow } from './workflow-layout.types';
 
 export interface SidebarProps {
-  workflows: string[];
-  onSelect: (wf: string) => void;
+  onSelect: (workflowName: string) => void;
   selected: string | null;
-  workflowMetadata: WorkflowMetadata | null;
-  onUpdateMetadata: (metadata: WorkflowMetadata) => Promise<void>;
-  allWorkflowsMetadata?: Record<string, WorkflowMetadata>;
+  workflowsData: Record<string, Workflow>;
+  onUpdateWorkflow: (workflowName: string, workflow: Workflow) => Promise<void>;
 }

--- a/ui/src/types/workflow-layout.types.ts
+++ b/ui/src/types/workflow-layout.types.ts
@@ -60,7 +60,7 @@ export interface WorkflowMetadata {
 export interface WorkflowItemProps {
   id: string;
   selected: boolean;
-  metadata?: WorkflowMetadata;
+  workflow?: Workflow;
   onSelect: (id: string) => void;
-  onUpdateMetadata: (m: WorkflowMetadata) => Promise<void>;
+  onUpdateWorkflow: (workflow: Workflow) => Promise<void>;
 }

--- a/ui/src/utils/extract-metadata.ts
+++ b/ui/src/utils/extract-metadata.ts
@@ -1,0 +1,13 @@
+import { WorkflowMetadata, Workflow } from '../types/workflow-layout.types';
+
+export function extractMetadata(workflow: Workflow): WorkflowMetadata {
+  const metadata: WorkflowMetadata = {
+    name: workflow.name,
+    description: workflow.description,
+    version: workflow.version,
+    input_schema: workflow.input_schema,
+    workflow_analysis: workflow.workflow_analysis
+  };
+  
+  return metadata;
+}

--- a/ui/src/utils/json-to-flow.ts
+++ b/ui/src/utils/json-to-flow.ts
@@ -1,36 +1,26 @@
 import { Edge } from '@xyflow/react';
-import { Workflow, WorkflowStep, WorkflowMetadata, AppNode } from '../types/workflow-layout.types';
+import { Workflow, WorkflowStep, AppNode } from '../types/workflow-layout.types';
 
-export function jsonToFlow(workflow: string): { 
+export function jsonToFlow(workflow: Workflow): { 
   nodes: AppNode[]; 
   edges: Edge[];
-  metadata: WorkflowMetadata;
 } {
-  const parsedWorkflow = JSON.parse(workflow) as Workflow;
-  const nodes: AppNode[] = parsedWorkflow.steps.map((step: WorkflowStep, idx: number) => ({
+  const nodes: AppNode[] = workflow.steps.map((step: WorkflowStep, idx: number) => ({
     id: String(idx),
     data: { 
       label: `${step.description}`, 
       stepData: step,
-      workflowName: parsedWorkflow.name
+      workflowName: workflow.name
     },
     position: { x: 0, y: idx * 100 }
   }));
 
-  const edges: Edge[] = parsedWorkflow.steps.slice(1).map((_, idx) => ({
+  const edges: Edge[] = workflow.steps.slice(1).map((_, idx) => ({
     id: `e${idx}-${idx + 1}`,
     source: String(idx),
     target: String(idx + 1),
     animated: true,
   }));
 
-  const metadata: WorkflowMetadata = {
-    name: parsedWorkflow.name,
-    description: parsedWorkflow.description,
-    version: parsedWorkflow.version,
-    input_schema: parsedWorkflow.input_schema,
-    workflow_analysis: parsedWorkflow.workflow_analysis
-  };
-
-  return { nodes, edges, metadata };
+  return { nodes, edges };
 }


### PR DESCRIPTION
## Overview

I realized in the initial implementation that it was a bit convoluted how we handled workflow metadata vs step data, even though they are coming from the same place. The changes focus on using the full Workflow objects directly throughout the component tree rather than extracting and passing metadata separately.

## Key Changes
- All components now work with the same workflow data objects
- Components receive the full workflow data instead of just metadata
- Created a unified workflow refresh function that handles both fetching and updating
- Separating extracting metadata from workflow data object from json to flow function
- Move type definitions for sidebar to types file
- API calls for metadata updates are followed by a refresh to ensure consistency

I was not sure if you wanted to still separate updating metadata vs workflow steps on the backend, so I left that intact for now. Let me know if you have any thoughts or feedback.