### PR TITLE
Type safe outputs from a workflow

### DIFF
--- a/workflows/backend/service.py
+++ b/workflows/backend/service.py
@@ -169,13 +169,13 @@ class WorkflowService:
 					'extracted_content': s.extracted_content,
 					'status': 'completed',
 				}
-				for i, s in enumerate(result)
+				for i, s in enumerate(result.step_results)
 			]
 			for step in formatted_result:
 				await self._write_log(log_file, f'[{ts}] Completed step {step["step_id"]}: {step["extracted_content"]}\n')
 
 			self.active_tasks[task_id].update({'status': 'completed', 'result': formatted_result})
-			await self._write_log(log_file, f'[{ts}] Workflow completed successfully with {len(result)} steps\n')
+			await self._write_log(log_file, f'[{ts}] Workflow completed successfully with {len(result.step_results)} steps\n')
 
 		except asyncio.CancelledError:
 			await self._write_log(log_file, f'[{time.strftime("%Y-%m-%d %H:%M:%S")}] Workflow force‑cancelled\n')
@@ -185,10 +185,11 @@ class WorkflowService:
 			await self._write_log(log_file, f'[{time.strftime("%Y-%m-%d %H:%M:%S")}] Error: {exc}\n')
 			self.active_tasks[task_id].update({'status': 'failed', 'error': str(exc)})
 
-	def get_task_status(self, task_id: str) -> Dict[str, Any]:
+	def get_task_status(self, task_id: str) -> Dict[str, Any] | None:
 		task_info = self.active_tasks.get(task_id)
 		if not task_info:
 			return None
+
 		return {
 			'task_id': task_id,
 			'status': task_info['status'],

--- a/workflows/backend/service.py
+++ b/workflows/backend/service.py
@@ -187,7 +187,7 @@ class WorkflowService:
 
 			self.active_tasks[task_id].status = 'completed'
 			self.active_tasks[task_id].result = formatted_result
-			await self._write_log(log_file, f'[{ts}] Workflow completed successfully with {len(result)} steps\n')
+			await self._write_log(log_file, f'[{ts}] Workflow completed successfully with {len(result.step_results)} steps\n')
 
 		except asyncio.CancelledError:
 			await self._write_log(log_file, f'[{time.strftime("%Y-%m-%d %H:%M:%S")}] Workflow force‑cancelled\n')

--- a/workflows/cli.py
+++ b/workflows/cli.py
@@ -420,7 +420,9 @@ def mcp_server_command(
 	typer.echo()  # Add space
 
 	llm_instance = ChatOpenAI(model='gpt-4o')
-	mcp = get_mcp_server(llm_instance, workflow_dir='./tmp')
+	page_extraction_llm = ChatOpenAI(model='gpt-4o-mini')
+
+	mcp = get_mcp_server(llm_instance, page_extraction_llm=page_extraction_llm, workflow_dir='./tmp')
 
 	mcp.run(
 		transport='sse',

--- a/workflows/cli.py
+++ b/workflows/cli.py
@@ -31,12 +31,14 @@ app = typer.Typer(
 llm_instance = None
 try:
 	llm_instance = ChatOpenAI(model='gpt-4o')
+	page_extraction_llm = ChatOpenAI(model='gpt-4o-mini')
 except Exception as e:
 	typer.secho(f'Error initializing LLM: {e}. Would you like to set your OPENAI_API_KEY?', fg=typer.colors.RED)
 	set_openai_api_key = input('Set OPENAI_API_KEY? (y/n): ')
 	if set_openai_api_key.lower() == 'y':
 		os.environ['OPENAI_API_KEY'] = input('Enter your OPENAI_API_KEY: ')
 		llm_instance = ChatOpenAI(model='gpt-4o')
+		page_extraction_llm = ChatOpenAI(model='gpt-4o-mini')
 
 builder_service = BuilderService(llm=llm_instance) if llm_instance else None
 # recorder_service = RecorderService() # Placeholder
@@ -150,7 +152,6 @@ def create_workflow():
 	"""
 	if not recording_service:
 		# Adjusted RecordingService initialization check assuming it doesn't need LLM
-		# If it does, this check should be more robust (e.g. based on llm_instance)
 		typer.secho(
 			'RecordingService not available. Cannot create workflow.',
 			fg=typer.colors.RED,
@@ -278,7 +279,7 @@ def run_as_tool_command(
 
 	try:
 		# Pass llm_instance to ensure the workflow can use it if needed for as_tool() or run_with_prompt()
-		workflow_obj = Workflow.load_from_file(str(workflow_path), llm=llm_instance)
+		workflow_obj = Workflow.load_from_file(str(workflow_path), llm=llm_instance, page_extraction_llm=page_extraction_llm)
 	except Exception as e:
 		typer.secho(f'Error loading workflow: {e}', fg=typer.colors.RED)
 		raise typer.Exit(code=1)
@@ -327,7 +328,11 @@ def run_workflow_command(
 		browser_instance = Browser()  # Add any necessary config if required
 		controller_instance = WorkflowController()  # Add any necessary config if required
 		workflow_obj = Workflow.load_from_file(
-			str(workflow_path), llm=llm_instance, browser=browser_instance, controller=controller_instance
+			str(workflow_path),
+			llm=llm_instance,
+			browser=browser_instance,
+			controller=controller_instance,
+			page_extraction_llm=page_extraction_llm,
 		)
 	except Exception as e:
 		typer.secho(f'Error loading workflow: {e}', fg=typer.colors.RED)
@@ -388,7 +393,7 @@ def run_workflow_command(
 		typer.secho('\nWorkflow execution completed!', fg=typer.colors.GREEN, bold=True)
 		typer.echo(typer.style('Result:', bold=True))
 		# Output the number of steps executed, similar to previous behavior
-		typer.echo(f'{typer.style(str(len(result)), bold=True)} steps executed.')
+		typer.echo(f'{typer.style(str(len(result.step_results)), bold=True)} steps executed.')
 		# For more detailed results, one might want to iterate through the 'result' list
 		# and print each item, or serialize the whole list to JSON.
 		# For now, sticking to the step count as per original output.

--- a/workflows/pyproject.toml
+++ b/workflows/pyproject.toml
@@ -45,7 +45,7 @@ indent-style = "tab"
 docstring-code-format = true
 
 [tool.pyright]
-typeCheckingMode = "off"
+typeCheckingMode = "basic"
 
 [build-system]
 requires = ["hatchling"]

--- a/workflows/workflow_use/builder/prompts.py
+++ b/workflows/workflow_use/builder/prompts.py
@@ -34,6 +34,7 @@ Follow these rules when generating the output JSON:
        - Evaluating content to match user input (e.g., finding a specific item based on its name or attributes).
      - Break complex tasks into multiple specific agentic steps rather than one broad task.
      - **Use the user’s goal (if provided) or inferred intent from the recording** to identify where agentic steps are needed for dynamic content, even if the recording uses deterministic steps.
+   - **extract_page_content** - Use this type when you want to extract data from the page. If the task is simply extracting data from the page, use this instead of agentic steps (never create agentic step for simple data extraction).
    - **Deterministic events** → keep the original recorder event structure. The
      value of `"type"` MUST match **exactly** one of the available action
      names listed below; all additional keys are interpreted as parameters for

--- a/workflows/workflow_use/builder/service.py
+++ b/workflows/workflow_use/builder/service.py
@@ -19,323 +19,265 @@ logger = logging.getLogger(__name__)
 
 
 class BuilderService:
-    """
-    Service responsible for building executable workflow JSON definitions
-    from recorded browser session events using an LLM.
-    """
+	"""
+	Service responsible for building executable workflow JSON definitions
+	from recorded browser session events using an LLM.
+	"""
 
-    def __init__(self, llm: BaseChatModel):
-        """
-        Initializes the BuilderService.
+	def __init__(self, llm: BaseChatModel):
+		"""
+		Initializes the BuilderService.
 
-        Args:
-            llm: A LangChain BaseChatModel instance configured for use.
-                 It should ideally support vision capabilities if screenshots are used.
-        """
-        if llm is None:
-            raise ValueError("A BaseChatModel instance must be provided.")
+		Args:
+		    llm: A LangChain BaseChatModel instance configured for use.
+		         It should ideally support vision capabilities if screenshots are used.
+		"""
+		if llm is None:
+			raise ValueError('A BaseChatModel instance must be provided.')
 
-        # Configure the LLM to return structured output based on the Pydantic model
-        try:
-            # Specify method="function_calling" for better compatibility
-            self.llm_structured = llm.with_structured_output(
-                WorkflowDefinitionSchema, method="function_calling"
-            )
-        except NotImplementedError:
-            logger.warning(
-                "LLM does not support structured output natively. Falling back."
-            )
-            # Basic LLM call if structured output is not supported
-            # Output parsing will be handled manually later
-            self.llm_structured = llm  # Store the original llm
+		# Configure the LLM to return structured output based on the Pydantic model
+		try:
+			# Specify method="function_calling" for better compatibility
+			self.llm_structured = llm.with_structured_output(WorkflowDefinitionSchema, method='function_calling')
+		except NotImplementedError:
+			logger.warning('LLM does not support structured output natively. Falling back.')
+			# Basic LLM call if structured output is not supported
+			# Output parsing will be handled manually later
+			self.llm_structured = llm  # Store the original llm
 
-        self.prompt_template = PromptTemplate.from_template(
-            WORKFLOW_BUILDER_PROMPT_TEMPLATE
-        )
-        self.actions_markdown = self._get_available_actions_markdown()
-        logger.info("BuilderService initialized.")
+		self.prompt_template = PromptTemplate.from_template(WORKFLOW_BUILDER_PROMPT_TEMPLATE)
+		self.actions_markdown = self._get_available_actions_markdown()
+		logger.info('BuilderService initialized.')
 
-    def _get_available_actions_markdown(self) -> str:
-        """Return a markdown list of available actions and their schema."""
-        controller = WorkflowController()
-        lines: List[str] = []
-        for action in controller.registry.registry.actions.values():
-            # Only include deterministic actions relevant for building from recordings
-            # Exclude agent-specific or meta-actions if necessary
-            # Based on schema/views.py, the recorder types seem to map directly
-            # to controller action *names*, but the prompt uses the event `type` field.
-            # Let's assume the prompt template correctly lists the *event types* expected.
-            # This function provides the detailed schema for the LLM.
-            schema_info = action.param_model.model_json_schema()
-            # Simplify schema representation for the prompt if too verbose
-            param_details = []
-            props = schema_info.get("properties", {})
-            required = schema_info.get("required", [])
-            for name, details in props.items():
-                req_star = "*" if name in required else ""
-                param_details.append(
-                    f"`{name}`{req_star} ({details.get('type', 'any')})"
-                )
+	def _get_available_actions_markdown(self) -> str:
+		"""Return a markdown list of available actions and their schema."""
+		controller = WorkflowController()
+		lines: List[str] = []
+		for action in controller.registry.registry.actions.values():
+			# Only include deterministic actions relevant for building from recordings
+			# Exclude agent-specific or meta-actions if necessary
+			# Based on schema/views.py, the recorder types seem to map directly
+			# to controller action *names*, but the prompt uses the event `type` field.
+			# Let's assume the prompt template correctly lists the *event types* expected.
+			# This function provides the detailed schema for the LLM.
+			schema_info = action.param_model.model_json_schema()
+			# Simplify schema representation for the prompt if too verbose
+			param_details = []
+			props = schema_info.get('properties', {})
+			required = schema_info.get('required', [])
+			for name, details in props.items():
+				req_star = '*' if name in required else ''
+				param_details.append(f'`{name}`{req_star} ({details.get("type", "any")})')
 
-            lines.append(
-                f"- **`{action.name}`**: {action.description}"
-            )  # Using action name from controller
-            if param_details:
-                lines.append(f"  - Parameters: {', '.join(param_details)}")
+			lines.append(f'- **`{action.name}`**: {action.description}')  # Using action name from controller
+			if param_details:
+				lines.append(f'  - Parameters: {", ".join(param_details)}')
 
-        # Add descriptions for agent/extract_content types manually if not in controller
-        if "agent" not in [
-            a.name for a in controller.registry.registry.actions.values()
-        ]:
-            lines.append("- **`agent`**: Executes a task using an autonomous agent.")
-            lines.append(
-                "  - Parameters: `task`* (string), `description` (string), `max_steps` (integer)"
-            )
-        # if "extract_content" not in [
-        #     a.name for a in controller.registry.registry.actions.values()
-        # ]:
-        #     lines.append(
-        #         "- **`extract_content`**: Uses an LLM to extract specific information from the current page."
-        #     )
-        #     lines.append(
-        #         "  - Parameters: `goal`* (string), `description` (string), `should_strip_link_urls` (boolean)"
-        #     )
+		# Add descriptions for agent/extract_content types manually if not in controller
+		if 'agent' not in [a.name for a in controller.registry.registry.actions.values()]:
+			lines.append('- **`agent`**: Executes a task using an autonomous agent.')
+			lines.append('  - Parameters: `task`* (string), `description` (string), `max_steps` (integer)')
+		# if "extract_content" not in [
+		#     a.name for a in controller.registry.registry.actions.values()
+		# ]:
+		#     lines.append(
+		#         "- **`extract_content`**: Uses an LLM to extract specific information from the current page."
+		#     )
+		#     lines.append(
+		#         "  - Parameters: `goal`* (string), `description` (string), `should_strip_link_urls` (boolean)"
+		#     )
 
-        logger.debug(f"Generated actions markdown:\n{lines}")
-        return "\n".join(lines)
+		logger.debug(f'Generated actions markdown:\n{lines}')
+		return '\n'.join(lines)
 
-    @staticmethod
-    def _find_first_user_interaction_url(events: List[Dict[str, Any]]) -> Optional[str]:
-        """Finds the URL of the first recorded user interaction."""
-        return next(
-            (
-                evt.get("frameUrl")
-                for evt in events
-                if evt.get("type")
-                in [
-                    "input",
-                    "click",
-                    "scroll",
-                    "select_change",
-                    "key_press",
-                ]  # Added more types
-            ),
-            None,
-        )
+	@staticmethod
+	def _find_first_user_interaction_url(events: List[Dict[str, Any]]) -> Optional[str]:
+		"""Finds the URL of the first recorded user interaction."""
+		return next(
+			(
+				evt.get('frameUrl')
+				for evt in events
+				if evt.get('type')
+				in [
+					'input',
+					'click',
+					'scroll',
+					'select_change',
+					'key_press',
+				]  # Added more types
+			),
+			None,
+		)
 
-    def _parse_llm_output_to_workflow(
-        self, llm_content: str
-    ) -> WorkflowDefinitionSchema:
-        """Attempts to parse the LLM string output into a WorkflowDefinitionSchema."""
-        logger.debug(f"Raw LLM Output:\n{llm_content}")
-        content_to_parse = llm_content
+	def _parse_llm_output_to_workflow(self, llm_content: str) -> WorkflowDefinitionSchema:
+		"""Attempts to parse the LLM string output into a WorkflowDefinitionSchema."""
+		logger.debug(f'Raw LLM Output:\n{llm_content}')
+		content_to_parse = llm_content
 
-        # Heuristic cleanup: Extract JSON from markdown code blocks
-        if "```json" in content_to_parse:
-            match = re.search(
-                r"```json\s*([\s\S]*?)\s*```", content_to_parse, re.DOTALL
-            )
-            if match:
-                content_to_parse = match.group(1).strip()
-                logger.debug("Extracted JSON from ```json block.")
-        elif content_to_parse.strip().startswith(
-            "{"
-        ) and content_to_parse.strip().endswith("}"):
-            # Assume it's already JSON if it looks like it
-            content_to_parse = content_to_parse.strip()
-            logger.debug("Assuming raw output is JSON.")
-        else:
-            logger.warning(
-                "Could not reliably extract JSON from LLM output, attempting parse anyway."
-            )
+		# Heuristic cleanup: Extract JSON from markdown code blocks
+		if '```json' in content_to_parse:
+			match = re.search(r'```json\s*([\s\S]*?)\s*```', content_to_parse, re.DOTALL)
+			if match:
+				content_to_parse = match.group(1).strip()
+				logger.debug('Extracted JSON from ```json block.')
+		elif content_to_parse.strip().startswith('{') and content_to_parse.strip().endswith('}'):
+			# Assume it's already JSON if it looks like it
+			content_to_parse = content_to_parse.strip()
+			logger.debug('Assuming raw output is JSON.')
+		else:
+			logger.warning('Could not reliably extract JSON from LLM output, attempting parse anyway.')
 
-        try:
-            # Try parsing directly first (might work with structured output)
-            workflow_data = WorkflowDefinitionSchema.model_validate_json(
-                content_to_parse
-            )
-            logger.info("Successfully parsed LLM output into WorkflowDefinitionSchema.")
-            return workflow_data
-        except (json.JSONDecodeError, ValidationError) as e:
-            logger.error(
-                f"Failed to parse LLM output into WorkflowDefinitionSchema: {e}"
-            )
-            logger.debug(f"Content attempted parsing:\n{content_to_parse}")
-            raise ValueError(
-                f"LLM output could not be parsed into a valid Workflow schema. Error: {e}"
-            ) from e
+		try:
+			# Try parsing directly first (might work with structured output)
+			workflow_data = WorkflowDefinitionSchema.model_validate_json(content_to_parse)
+			logger.info('Successfully parsed LLM output into WorkflowDefinitionSchema.')
+			return workflow_data
+		except (json.JSONDecodeError, ValidationError) as e:
+			logger.error(f'Failed to parse LLM output into WorkflowDefinitionSchema: {e}')
+			logger.debug(f'Content attempted parsing:\n{content_to_parse}')
+			raise ValueError(f'LLM output could not be parsed into a valid Workflow schema. Error: {e}') from e
 
-    async def build_workflow(
-        self,
-        input_workflow: WorkflowDefinitionSchema,
-        user_goal: str,
-        use_screenshots: bool = False,
-        max_images: int = 20,
-    ) -> WorkflowDefinitionSchema:
-        """
-        Generates an enhanced Workflow definition from an input workflow object using an LLM.
+	async def build_workflow(
+		self,
+		input_workflow: WorkflowDefinitionSchema,
+		user_goal: str,
+		use_screenshots: bool = False,
+		max_images: int = 20,
+	) -> WorkflowDefinitionSchema:
+		"""
+		Generates an enhanced Workflow definition from an input workflow object using an LLM.
 
-        Args:
-            input_workflow: The initial WorkflowDefinitionSchema object containing steps to process.
-            user_goal: Optional high-level description of the workflow's purpose.
-                       If None, the user might be prompted interactively.
-            use_screenshots: Whether to include screenshots as visual context for the LLM (if available in steps).
-            max_images: Maximum number of screenshots to include (to manage cost/tokens).
+		Args:
+		    input_workflow: The initial WorkflowDefinitionSchema object containing steps to process.
+		    user_goal: Optional high-level description of the workflow's purpose.
+		               If None, the user might be prompted interactively.
+		    use_screenshots: Whether to include screenshots as visual context for the LLM (if available in steps).
+		    max_images: Maximum number of screenshots to include (to manage cost/tokens).
 
-        Returns:
-            A new WorkflowDefinitionSchema object generated by the LLM.
+		Returns:
+		    A new WorkflowDefinitionSchema object generated by the LLM.
 
-        Raises:
-            ValueError: If the input workflow is invalid or the LLM output cannot be parsed.
-            Exception: For other LLM or processing errors.
-        """
-        # Validate input slightly
-        if not input_workflow or not isinstance(input_workflow.steps, list):
-            raise ValueError("Invalid input_workflow object provided.")
+		Raises:
+		    ValueError: If the input workflow is invalid or the LLM output cannot be parsed.
+		    Exception: For other LLM or processing errors.
+		"""
+		# Validate input slightly
+		if not input_workflow or not isinstance(input_workflow.steps, list):
+			raise ValueError('Invalid input_workflow object provided.')
 
-        # Handle user goal
-        goal = user_goal
-        if goal is None:
-            try:
-                goal = input(
-                    "Please describe the high-level task for the workflow (optional, press Enter to skip): "
-                ).strip()
-            except EOFError:  # Handle non-interactive environments
-                goal = ""
-        goal = goal or "Automate the recorded browser actions."  # Default goal if empty
+		# Handle user goal
+		goal = user_goal
+		if goal is None:
+			try:
+				goal = input('Please describe the high-level task for the workflow (optional, press Enter to skip): ').strip()
+			except EOFError:  # Handle non-interactive environments
+				goal = ''
+		goal = goal or 'Automate the recorded browser actions.'  # Default goal if empty
 
-        # Format the main instruction prompt
-        prompt_str = self.prompt_template.format(
-            actions=self.actions_markdown,
-            goal=goal,
-        )
+		# Format the main instruction prompt
+		prompt_str = self.prompt_template.format(
+			actions=self.actions_markdown,
+			goal=goal,
+		)
 
-        # Prepare the vision messages list
-        vision_messages: List[Dict[str, Any]] = [{"type": "text", "text": prompt_str}]
+		# Prepare the vision messages list
+		vision_messages: List[Dict[str, Any]] = [{'type': 'text', 'text': prompt_str}]
 
-        # Integrate message preparation logic here
-        images_used = 0
-        for step in input_workflow.steps:
-            step_messages: List[Dict[str, Any]] = []  # Messages for this specific step
+		# Integrate message preparation logic here
+		images_used = 0
+		for step in input_workflow.steps:
+			step_messages: List[Dict[str, Any]] = []  # Messages for this specific step
 
-            # 1. Text representation (JSON dump)
-            step_dict = step.model_dump(mode="json", exclude_none=True)
-            screenshot_data = step_dict.pop(
-                "screenshot", None
-            )  # Pop potential screenshot
-            step_messages.append(
-                {"type": "text", "text": json.dumps(step_dict, indent=2)}
-            )
+			# 1. Text representation (JSON dump)
+			step_dict = step.model_dump(mode='json', exclude_none=True)
+			screenshot_data = step_dict.pop('screenshot', None)  # Pop potential screenshot
+			step_messages.append({'type': 'text', 'text': json.dumps(step_dict, indent=2)})
 
-            # 2. Optional screenshot
-            attach_image = use_screenshots and images_used < max_images
-            step_type = getattr(step, "type", step_dict.get("type"))
+			# 2. Optional screenshot
+			attach_image = use_screenshots and images_used < max_images
+			step_type = getattr(step, 'type', step_dict.get('type'))
 
-            if attach_image and step_type != "input":  # Don't attach for inputs
-                # Re-retrieve screenshot data if it wasn't popped (e.g., nested under 'data')
-                # This assumes screenshot might still be in the original step model or dict
-                # A bit redundant, ideally screenshot handling is consistent
-                screenshot = (
-                    screenshot_data
-                    or getattr(step, "screenshot", None)
-                    or step_dict.get("data", {}).get("screenshot")
-                )
+			if attach_image and step_type != 'input':  # Don't attach for inputs
+				# Re-retrieve screenshot data if it wasn't popped (e.g., nested under 'data')
+				# This assumes screenshot might still be in the original step model or dict
+				# A bit redundant, ideally screenshot handling is consistent
+				screenshot = screenshot_data or getattr(step, 'screenshot', None) or step_dict.get('data', {}).get('screenshot')
 
-                if screenshot:
-                    if isinstance(screenshot, str) and screenshot.startswith("data:"):
-                        screenshot = screenshot.split(",", 1)[-1]
+				if screenshot:
+					if isinstance(screenshot, str) and screenshot.startswith('data:'):
+						screenshot = screenshot.split(',', 1)[-1]
 
-                    # Validate base64 payload
-                    try:
-                        base64.b64decode(cast(str, screenshot), validate=True)
-                        meta = f"<Screenshot for event type '{step_type}'>"
-                        step_messages.append({"type": "text", "text": meta})
-                        step_messages.append(
-                            {
-                                "type": "image_url",
-                                "image_url": {
-                                    "url": f"data:image/png;base64,{screenshot}"
-                                },
-                            }
-                        )
-                        images_used += (
-                            1  # Increment image count *only* if successfully added
-                        )
-                    except (TypeError, ValueError, Exception) as e:
-                        logger.warning(
-                            f"Invalid or missing screenshot for step type '{step_type}' "
-                            f"@ {step_dict.get('timestamp', '')}. Error: {e}"
-                        )
-                        # Don't add image messages if invalid
+					# Validate base64 payload
+					try:
+						base64.b64decode(cast(str, screenshot), validate=True)
+						meta = f"<Screenshot for event type '{step_type}'>"
+						step_messages.append({'type': 'text', 'text': meta})
+						step_messages.append(
+							{
+								'type': 'image_url',
+								'image_url': {'url': f'data:image/png;base64,{screenshot}'},
+							}
+						)
+						images_used += 1  # Increment image count *only* if successfully added
+					except (TypeError, ValueError, Exception) as e:
+						logger.warning(
+							f"Invalid or missing screenshot for step type '{step_type}' "
+							f'@ {step_dict.get("timestamp", "")}. Error: {e}'
+						)
+						# Don't add image messages if invalid
 
-            # Add the messages for this step to the main list
-            vision_messages.extend(step_messages)
+			# Add the messages for this step to the main list
+			vision_messages.extend(step_messages)
 
-        logger.info(
-            f"Prepared {len(vision_messages)} total message parts, including {images_used} images."
-        )
+		logger.info(f'Prepared {len(vision_messages)} total message parts, including {images_used} images.')
 
-        # Invoke the LLM (structured output preferred)
-        try:
-            # Invoke the LLM (structured output preferred)
-            # Need to handle cases where structured output isn't truly supported
-            if hasattr(
-                self.llm_structured, "output_schema"
-            ):  # Check if it seems like structured output model
-                llm_response = await self.llm_structured.ainvoke(
-                    [HumanMessage(content=cast(Any, vision_messages))]
-                )
-                # If structured output worked, llm_response is the Pydantic object
-                if isinstance(llm_response, WorkflowDefinitionSchema):
-                    workflow_data = llm_response
-                else:
-                    # It might have returned a message or dict, try parsing its content
-                    content = getattr(llm_response, "content", str(llm_response))
-                    workflow_data = self._parse_llm_output_to_workflow(str(content))
-            else:
-                # Fallback to basic LLM call and manual parsing
-                llm_response = await self.llm_structured.ainvoke(
-                    [HumanMessage(content=cast(Any, vision_messages))]
-                )
-                llm_content = str(
-                    getattr(llm_response, "content", llm_response)
-                )  # Get string content
-                workflow_data = self._parse_llm_output_to_workflow(llm_content)
+		# Invoke the LLM (structured output preferred)
+		try:
+			# Invoke the LLM (structured output preferred)
+			# Need to handle cases where structured output isn't truly supported
+			if hasattr(self.llm_structured, 'output_schema'):  # Check if it seems like structured output model
+				llm_response = await self.llm_structured.ainvoke([HumanMessage(content=cast(Any, vision_messages))])
+				# If structured output worked, llm_response is the Pydantic object
+				if isinstance(llm_response, WorkflowDefinitionSchema):
+					workflow_data = llm_response
+				else:
+					# It might have returned a message or dict, try parsing its content
+					content = getattr(llm_response, 'content', str(llm_response))
+					workflow_data = self._parse_llm_output_to_workflow(str(content))
+			else:
+				# Fallback to basic LLM call and manual parsing
+				llm_response = await self.llm_structured.ainvoke([HumanMessage(content=cast(Any, vision_messages))])
+				llm_content = str(getattr(llm_response, 'content', llm_response))  # Get string content
+				workflow_data = self._parse_llm_output_to_workflow(llm_content)
 
-        except OutputParserException as ope:
-            logger.error(f"LLM output parsing failed (OutputParserException): {ope}")
-            # Try to parse the raw output as a fallback
-            raw_output = getattr(ope, "llm_output", str(ope))
-            logger.info("Attempting to parse raw output as fallback...")
-            try:
-                workflow_data = self._parse_llm_output_to_workflow(raw_output)
-            except ValueError as ve_fallback:
-                raise ValueError(
-                    f"LLM structured output failed, and fallback parsing also failed. Error: {ve_fallback}"
-                ) from ve_fallback
-        except Exception as e:
-            logger.exception(
-                f"An error occurred during LLM invocation or processing: {e}"
-            )
-            raise  # Re-raise other unexpected errors
+		except OutputParserException as ope:
+			logger.error(f'LLM output parsing failed (OutputParserException): {ope}')
+			# Try to parse the raw output as a fallback
+			raw_output = getattr(ope, 'llm_output', str(ope))
+			logger.info('Attempting to parse raw output as fallback...')
+			try:
+				workflow_data = self._parse_llm_output_to_workflow(raw_output)
+			except ValueError as ve_fallback:
+				raise ValueError(
+					f'LLM structured output failed, and fallback parsing also failed. Error: {ve_fallback}'
+				) from ve_fallback
+		except Exception as e:
+			logger.exception(f'An error occurred during LLM invocation or processing: {e}')
+			raise  # Re-raise other unexpected errors
 
-        # Return the workflow data object directly
-        return workflow_data
+		# Return the workflow data object directly
+		return workflow_data
 
-    # path handlers
-    async def build_workflow_from_path(
-        self, path: Path, user_goal: str
-    ) -> WorkflowDefinitionSchema:
-        """Build a workflow from a JSON file path."""
-        with open(path, "r") as f:
-            workflow_data = json.load(f)
+	# path handlers
+	async def build_workflow_from_path(self, path: Path, user_goal: str) -> WorkflowDefinitionSchema:
+		"""Build a workflow from a JSON file path."""
+		with open(path, 'r') as f:
+			workflow_data = json.load(f)
 
-        workflow_data_schema = WorkflowDefinitionSchema.model_validate(workflow_data)
-        return await self.build_workflow(workflow_data_schema, user_goal)
+		workflow_data_schema = WorkflowDefinitionSchema.model_validate(workflow_data)
+		return await self.build_workflow(workflow_data_schema, user_goal)
 
-    async def save_workflow_to_path(
-        self, workflow: WorkflowDefinitionSchema, path: Path
-    ):
-        """Save a workflow to a JSON file path."""
-        with open(path, "w") as f:
-            json.dump(workflow.model_dump(mode="json"), f, indent=2)
+	async def save_workflow_to_path(self, workflow: WorkflowDefinitionSchema, path: Path):
+		"""Save a workflow to a JSON file path."""
+		with open(path, 'w') as f:
+			json.dump(workflow.model_dump(mode='json'), f, indent=2)

--- a/workflows/workflow_use/builder/tests/build_workflow.py
+++ b/workflows/workflow_use/builder/tests/build_workflow.py
@@ -7,25 +7,25 @@ from langchain_openai import ChatOpenAI
 from workflow_use.builder.service import BuilderService
 
 # Instantiate the LLM and the service directly
-llm_instance = ChatOpenAI(model="gpt-4o")  # Or your preferred model
+llm_instance = ChatOpenAI(model='gpt-4o')  # Or your preferred model
 builder_service = BuilderService(llm=llm_instance)
 
 
 async def test_build_workflow_from_path():
-    """
-    Tests that the workflow is built correctly from a JSON file path.
-    """
-    path = Path(__file__).parent / "tmp" / "recording.json"
-    workflow_definition = await builder_service.build_workflow_from_path(
-        path,
-        "go to apple.com and extract the price of the iphone XY (where XY is a variable)",
-    )
+	"""
+	Tests that the workflow is built correctly from a JSON file path.
+	"""
+	path = Path(__file__).parent / 'tmp' / 'recording.json'
+	workflow_definition = await builder_service.build_workflow_from_path(
+		path,
+		'go to apple.com and extract the price of the iphone XY (where XY is a variable)',
+	)
 
-    print(workflow_definition)
+	print(workflow_definition)
 
-    output_path = path.with_suffix(".workflow.json")
-    await builder_service.save_workflow_to_path(workflow_definition, output_path)
+	output_path = path.with_suffix('.workflow.json')
+	await builder_service.save_workflow_to_path(workflow_definition, output_path)
 
 
-if __name__ == "__main__":
-    asyncio.run(test_build_workflow_from_path())
+if __name__ == '__main__':
+	asyncio.run(test_build_workflow_from_path())

--- a/workflows/workflow_use/controller/service.py
+++ b/workflows/workflow_use/controller/service.py
@@ -13,10 +13,10 @@ from workflow_use.controller.views import (
 	InputTextDeterministicAction,
 	KeyPressDeterministicAction,
 	NavigationAction,
+	PageExtractionAction,
 	ScrollDeterministicAction,
 	SelectDropdownOptionDeterministicAction,
 )
-from workflow_use.schema.views import PageExtractionStep
 
 logger = logging.getLogger(__name__)
 
@@ -209,8 +209,9 @@ class WorkflowController(Controller):
 
 		@self.registry.action(
 			'Extract page content to retrieve specific information from the page, e.g. all company names, a specific description, all information about, links with companies in structured format or simply links',
+			param_model=PageExtractionAction,
 		)
-		async def extract_content(params: PageExtractionStep, browser: BrowserContext, page_extraction_llm: BaseChatModel):
+		async def extract_page_content(params: PageExtractionAction, browser: BrowserContext, page_extraction_llm: BaseChatModel):
 			page = await browser.get_current_page()
 			import markdownify
 

--- a/workflows/workflow_use/controller/service.py
+++ b/workflows/workflow_use/controller/service.py
@@ -4,16 +4,19 @@ import logging
 from browser_use.agent.views import ActionResult
 from browser_use.browser.context import BrowserContext
 from browser_use.controller.service import Controller
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.prompts import PromptTemplate
 
 from workflow_use.controller.utils import get_best_element_handle, truncate_selector
 from workflow_use.controller.views import (
-    ClickElementDeterministicAction,
-    InputTextDeterministicAction,
-    KeyPressDeterministicAction,
-    NavigationAction,
-    ScrollDeterministicAction,
-    SelectDropdownOptionDeterministicAction,
+	ClickElementDeterministicAction,
+	InputTextDeterministicAction,
+	KeyPressDeterministicAction,
+	NavigationAction,
+	ScrollDeterministicAction,
+	SelectDropdownOptionDeterministicAction,
 )
+from workflow_use.schema.views import PageExtractionStep
 
 logger = logging.getLogger(__name__)
 
@@ -22,194 +25,214 @@ DEFAULT_ACTION_TIMEOUT_MS = 1000
 # List of default actions from browser_use.controller.service.Controller to disable
 # todo: come up with a better way to filter out the actions (filter IN the actions would be much nicer in this case)
 DISABLED_DEFAULT_ACTIONS = [
-    "done",
-    "search_google",
-    "go_to_url",  # I am using this action from the main controller to avoid duplication
-    "go_back",
-    "wait",
-    "click_element_by_index",
-    "input_text",
-    "save_pdf",
-    "switch_tab",
-    "open_tab",
-    "close_tab",
-    "extract_content",
-    "scroll_down",
-    "scroll_up",
-    "send_keys",
-    "scroll_to_text",
-    "get_dropdown_options",
-    "select_dropdown_option",
-    "drag_drop",
-    "get_sheet_contents",
-    "select_cell_or_range",
-    "get_range_contents",
-    "clear_selected_range",
-    "input_selected_cell_text",
-    "update_range_contents",
+	'done',
+	'search_google',
+	'go_to_url',  # I am using this action from the main controller to avoid duplication
+	'go_back',
+	'wait',
+	'click_element_by_index',
+	'input_text',
+	'save_pdf',
+	'switch_tab',
+	'open_tab',
+	'close_tab',
+	'extract_content',
+	'scroll_down',
+	'scroll_up',
+	'send_keys',
+	'scroll_to_text',
+	'get_dropdown_options',
+	'select_dropdown_option',
+	'drag_drop',
+	'get_sheet_contents',
+	'select_cell_or_range',
+	'get_range_contents',
+	'clear_selected_range',
+	'input_selected_cell_text',
+	'update_range_contents',
 ]
 
 
 class WorkflowController(Controller):
-    def __init__(self, *args, **kwargs):
-        # Pass the list of actions to exclude to the base class constructor
-        super().__init__(*args, exclude_actions=DISABLED_DEFAULT_ACTIONS, **kwargs)
-        self.__register_actions()
+	def __init__(self, *args, **kwargs):
+		# Pass the list of actions to exclude to the base class constructor
+		super().__init__(*args, exclude_actions=DISABLED_DEFAULT_ACTIONS, **kwargs)
+		self.__register_actions()
 
-    def __register_actions(self):
-        # Navigate to URL ------------------------------------------------------------
-        @self.registry.action("Manually navigate to URL", param_model=NavigationAction)
-        async def navigation(
-            params: NavigationAction, browser: BrowserContext
-        ) -> ActionResult:
-            """Navigate to the given URL."""
-            page = await browser.get_current_page()
-            await page.goto(params.url)
-            await page.wait_for_load_state()
+	def __register_actions(self):
+		# Navigate to URL ------------------------------------------------------------
+		@self.registry.action('Manually navigate to URL', param_model=NavigationAction)
+		async def navigation(params: NavigationAction, browser: BrowserContext) -> ActionResult:
+			"""Navigate to the given URL."""
+			page = await browser.get_current_page()
+			await page.goto(params.url)
+			await page.wait_for_load_state()
 
-            msg = f"🔗  Navigated to URL: {params.url}"
-            logger.info(msg)
-            return ActionResult(extracted_content=msg, include_in_memory=True)
+			msg = f'🔗  Navigated to URL: {params.url}'
+			logger.info(msg)
+			return ActionResult(extracted_content=msg, include_in_memory=True)
 
-        # Click element by CSS selector --------------------------------------------------
+		# Click element by CSS selector --------------------------------------------------
 
-        @self.registry.action(
-            "Click element by all available selectors",
-            param_model=ClickElementDeterministicAction,
-        )
-        async def click(
-            params: ClickElementDeterministicAction, browser: BrowserContext
-        ) -> ActionResult:
-            """Click the first element matching *params.cssSelector* with fallback mechanisms."""
-            page = await browser.get_current_page()
-            original_selector = params.cssSelector
+		@self.registry.action(
+			'Click element by all available selectors',
+			param_model=ClickElementDeterministicAction,
+		)
+		async def click(params: ClickElementDeterministicAction, browser: BrowserContext) -> ActionResult:
+			"""Click the first element matching *params.cssSelector* with fallback mechanisms."""
+			page = await browser.get_current_page()
+			original_selector = params.cssSelector
 
-            try:
-                locator, selector_used = await get_best_element_handle(
-                    page,
-                    params.cssSelector,
-                    params,
-                    timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
-                )
-                await locator.click(force=True)
+			try:
+				locator, selector_used = await get_best_element_handle(
+					page,
+					params.cssSelector,
+					params,
+					timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
+				)
+				await locator.click(force=True)
 
-                msg = f"🖱️  Clicked element with CSS selector: {truncate_selector(selector_used)} (original: {truncate_selector(original_selector)})"
-                logger.info(msg)
-                return ActionResult(extracted_content=msg, include_in_memory=True)
-            except Exception as e:
-                error_msg = f"Failed to click element. Original selector: {truncate_selector(original_selector)}. Error: {str(e)}"
-                logger.error(error_msg)
-                raise Exception(error_msg)
+				msg = f'🖱️  Clicked element with CSS selector: {truncate_selector(selector_used)} (original: {truncate_selector(original_selector)})'
+				logger.info(msg)
+				return ActionResult(extracted_content=msg, include_in_memory=True)
+			except Exception as e:
+				error_msg = f'Failed to click element. Original selector: {truncate_selector(original_selector)}. Error: {str(e)}'
+				logger.error(error_msg)
+				raise Exception(error_msg)
 
-        # Input text into element --------------------------------------------------------
-        @self.registry.action(
-            "Input text into an element by all available selectors",
-            param_model=InputTextDeterministicAction,
-        )
-        async def input(
-            params: InputTextDeterministicAction,
-            browser: BrowserContext,
-            has_sensitive_data: bool = False,
-        ) -> ActionResult:
-            """Fill text into the element located with *params.cssSelector*."""
-            page = await browser.get_current_page()
-            original_selector = params.cssSelector
+		# Input text into element --------------------------------------------------------
+		@self.registry.action(
+			'Input text into an element by all available selectors',
+			param_model=InputTextDeterministicAction,
+		)
+		async def input(
+			params: InputTextDeterministicAction,
+			browser: BrowserContext,
+			has_sensitive_data: bool = False,
+		) -> ActionResult:
+			"""Fill text into the element located with *params.cssSelector*."""
+			page = await browser.get_current_page()
+			original_selector = params.cssSelector
 
-            try:
-                locator, selector_used = await get_best_element_handle(
-                    page,
-                    params.cssSelector,
-                    params,
-                    timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
-                )
+			try:
+				locator, selector_used = await get_best_element_handle(
+					page,
+					params.cssSelector,
+					params,
+					timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
+				)
 
-                # Check if it's a SELECT element
-                is_select = await locator.evaluate('(el) => el.tagName === "SELECT"')
-                if is_select:
-                    return ActionResult(
-                        extracted_content="Ignored input into select element",
-                        include_in_memory=True,
-                    )
+				# Check if it's a SELECT element
+				is_select = await locator.evaluate('(el) => el.tagName === "SELECT"')
+				if is_select:
+					return ActionResult(
+						extracted_content='Ignored input into select element',
+						include_in_memory=True,
+					)
 
-                # Add a small delay and click to ensure the element is focused
-                await locator.fill(params.value)
-                await asyncio.sleep(0.5)
-                await locator.click(force=True)
-                await asyncio.sleep(0.5)
+				# Add a small delay and click to ensure the element is focused
+				await locator.fill(params.value)
+				await asyncio.sleep(0.5)
+				await locator.click(force=True)
+				await asyncio.sleep(0.5)
 
-                msg = f'⌨️  Input "{params.value}" into element with CSS selector: {truncate_selector(selector_used)} (original: {truncate_selector(original_selector)})'
-                logger.info(msg)
-                return ActionResult(extracted_content=msg, include_in_memory=True)
-            except Exception as e:
-                error_msg = f"Failed to input text. Original selector: {truncate_selector(original_selector)}. Error: {str(e)}"
-                logger.error(error_msg)
-                raise Exception(error_msg)
+				msg = f'⌨️  Input "{params.value}" into element with CSS selector: {truncate_selector(selector_used)} (original: {truncate_selector(original_selector)})'
+				logger.info(msg)
+				return ActionResult(extracted_content=msg, include_in_memory=True)
+			except Exception as e:
+				error_msg = f'Failed to input text. Original selector: {truncate_selector(original_selector)}. Error: {str(e)}'
+				logger.error(error_msg)
+				raise Exception(error_msg)
 
-        # Select dropdown option ---------------------------------------------------------
-        @self.registry.action(
-            "Select dropdown option by all available selectors and visible text",
-            param_model=SelectDropdownOptionDeterministicAction,
-        )
-        async def select_change(
-            params: SelectDropdownOptionDeterministicAction, browser: BrowserContext
-        ) -> ActionResult:
-            """Select dropdown option whose visible text equals *params.value*."""
-            page = await browser.get_current_page()
-            original_selector = params.cssSelector
+		# Select dropdown option ---------------------------------------------------------
+		@self.registry.action(
+			'Select dropdown option by all available selectors and visible text',
+			param_model=SelectDropdownOptionDeterministicAction,
+		)
+		async def select_change(params: SelectDropdownOptionDeterministicAction, browser: BrowserContext) -> ActionResult:
+			"""Select dropdown option whose visible text equals *params.value*."""
+			page = await browser.get_current_page()
+			original_selector = params.cssSelector
 
-            try:
-                locator, selector_used = await get_best_element_handle(
-                    page,
-                    params.cssSelector,
-                    params,
-                    timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
-                )
+			try:
+				locator, selector_used = await get_best_element_handle(
+					page,
+					params.cssSelector,
+					params,
+					timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
+				)
 
-                await locator.select_option(label=params.selectedText)
+				await locator.select_option(label=params.selectedText)
 
-                msg = f'Selected option "{params.selectedText}" in dropdown {truncate_selector(selector_used)} (original: {truncate_selector(original_selector)})'
-                logger.info(msg)
-                return ActionResult(extracted_content=msg, include_in_memory=True)
-            except Exception as e:
-                error_msg = f"Failed to select option. Original selector: {truncate_selector(original_selector)}. Error: {str(e)}"
-                logger.error(error_msg)
-                raise Exception(error_msg)
+				msg = f'Selected option "{params.selectedText}" in dropdown {truncate_selector(selector_used)} (original: {truncate_selector(original_selector)})'
+				logger.info(msg)
+				return ActionResult(extracted_content=msg, include_in_memory=True)
+			except Exception as e:
+				error_msg = f'Failed to select option. Original selector: {truncate_selector(original_selector)}. Error: {str(e)}'
+				logger.error(error_msg)
+				raise Exception(error_msg)
 
-        # Key press action ------------------------------------------------------------
-        @self.registry.action(
-            "Press key on element by all available selectors",
-            param_model=KeyPressDeterministicAction,
-        )
-        async def key_press(
-            params: KeyPressDeterministicAction, browser: BrowserContext
-        ) -> ActionResult:
-            """Press *params.key* on the element identified by *params.cssSelector*."""
-            page = await browser.get_current_page()
-            original_selector = params.cssSelector
+		# Key press action ------------------------------------------------------------
+		@self.registry.action(
+			'Press key on element by all available selectors',
+			param_model=KeyPressDeterministicAction,
+		)
+		async def key_press(params: KeyPressDeterministicAction, browser: BrowserContext) -> ActionResult:
+			"""Press *params.key* on the element identified by *params.cssSelector*."""
+			page = await browser.get_current_page()
+			original_selector = params.cssSelector
 
-            try:
-                locator, selector_used = await get_best_element_handle(
-                    page, params.cssSelector, params, timeout_ms=5000
-                )
+			try:
+				locator, selector_used = await get_best_element_handle(page, params.cssSelector, params, timeout_ms=5000)
 
-                await locator.press(params.key)
+				await locator.press(params.key)
 
-                msg = f"🔑  Pressed key '{params.key}' on element with CSS selector: {truncate_selector(selector_used)} (original: {truncate_selector(original_selector)})"
-                logger.info(msg)
-                return ActionResult(extracted_content=msg, include_in_memory=True)
-            except Exception as e:
-                error_msg = f"Failed to press key. Original selector: {truncate_selector(original_selector)}. Error: {str(e)}"
-                logger.error(error_msg)
-                raise Exception(error_msg)
+				msg = f"🔑  Pressed key '{params.key}' on element with CSS selector: {truncate_selector(selector_used)} (original: {truncate_selector(original_selector)})"
+				logger.info(msg)
+				return ActionResult(extracted_content=msg, include_in_memory=True)
+			except Exception as e:
+				error_msg = f'Failed to press key. Original selector: {truncate_selector(original_selector)}. Error: {str(e)}'
+				logger.error(error_msg)
+				raise Exception(error_msg)
 
-        # Scroll action --------------------------------------------------------------
-        @self.registry.action("Scroll page", param_model=ScrollDeterministicAction)
-        async def scroll(
-            params: ScrollDeterministicAction, browser: BrowserContext
-        ) -> ActionResult:
-            """Scroll the page by the given x/y pixel offsets."""
-            page = await browser.get_current_page()
-            await page.evaluate(f"window.scrollBy({params.scrollX}, {params.scrollY});")
-            msg = f"📜  Scrolled page by (x={params.scrollX}, y={params.scrollY})"
-            logger.info(msg)
-            return ActionResult(extracted_content=msg, include_in_memory=True)
+		# Scroll action --------------------------------------------------------------
+		@self.registry.action('Scroll page', param_model=ScrollDeterministicAction)
+		async def scroll(params: ScrollDeterministicAction, browser: BrowserContext) -> ActionResult:
+			"""Scroll the page by the given x/y pixel offsets."""
+			page = await browser.get_current_page()
+			await page.evaluate(f'window.scrollBy({params.scrollX}, {params.scrollY});')
+			msg = f'📜  Scrolled page by (x={params.scrollX}, y={params.scrollY})'
+			logger.info(msg)
+			return ActionResult(extracted_content=msg, include_in_memory=True)
+
+			# Extract content ------------------------------------------------------------
+
+		@self.registry.action(
+			'Extract page content to retrieve specific information from the page, e.g. all company names, a specific description, all information about, links with companies in structured format or simply links',
+		)
+		async def extract_content(params: PageExtractionStep, browser: BrowserContext, page_extraction_llm: BaseChatModel):
+			page = await browser.get_current_page()
+			import markdownify
+
+			strip = ['a', 'img']
+
+			content = markdownify.markdownify(await page.content(), strip=strip)
+
+			# manually append iframe text into the content so it's readable by the LLM (includes cross-origin iframes)
+			for iframe in page.frames:
+				if iframe.url != page.url and not iframe.url.startswith('data:'):
+					content += f'\n\nIFRAME {iframe.url}:\n'
+					content += markdownify.markdownify(await iframe.content())
+
+			prompt = 'Your task is to extract the content of the page. You will be given a page and a goal and you should extract all relevant information around this goal from the page. If the goal is vague, summarize the page. Respond in json format. Extraction goal: {goal}, Page: {page}'
+			template = PromptTemplate(input_variables=['goal', 'page'], template=prompt)
+			try:
+				output = await page_extraction_llm.ainvoke(template.format(goal=params.goal, page=content))
+				msg = f'📄  Extracted from page\n: {output.content}\n'
+				logger.info(msg)
+				return ActionResult(extracted_content=msg, include_in_memory=True)
+			except Exception as e:
+				logger.debug(f'Error extracting content: {e}')
+				msg = f'📄  Extracted from page\n: {content}\n'
+				logger.info(msg)
+				return ActionResult(extracted_content=msg)

--- a/workflows/workflow_use/controller/utils.py
+++ b/workflows/workflow_use/controller/utils.py
@@ -1,5 +1,5 @@
-import re
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 

--- a/workflows/workflow_use/controller/utils.py
+++ b/workflows/workflow_use/controller/utils.py
@@ -3,156 +3,148 @@ import re
 
 logger = logging.getLogger(__name__)
 
+
 def truncate_selector(selector: str, max_length: int = 35) -> str:
-    """Truncate a CSS selector to a maximum length, adding ellipsis if truncated."""
-    return selector if len(selector) <= max_length else f"{selector[:max_length]}..."
+	"""Truncate a CSS selector to a maximum length, adding ellipsis if truncated."""
+	return selector if len(selector) <= max_length else f'{selector[:max_length]}...'
+
 
 async def get_best_element_handle(page, selector, params=None, timeout_ms=500):
-    """Find element using stability-ranked selector strategies."""
-    original_selector = selector
+	"""Find element using stability-ranked selector strategies."""
+	original_selector = selector
 
-    # Generate stability-ranked fallback selectors
-    fallbacks = generate_stable_selectors(selector, params)
+	# Generate stability-ranked fallback selectors
+	fallbacks = generate_stable_selectors(selector, params)
 
-    # Try all selectors with exponential backoff for timeouts
-    selectors_to_try = [original_selector] + fallbacks
+	# Try all selectors with exponential backoff for timeouts
+	selectors_to_try = [original_selector] + fallbacks
 
-    for try_selector in selectors_to_try:
-        try:
-            logger.info(f"Trying selector: {truncate_selector(try_selector)}")
-            locator = page.locator(try_selector)
-            await locator.wait_for(state="visible", timeout=timeout_ms)
-            logger.info(f"Found element with selector: {truncate_selector(try_selector)}")
-            return locator, try_selector
-        except Exception as e:
-            logger.error(f"Selector failed: {truncate_selector(try_selector)} with error: {e}")
+	for try_selector in selectors_to_try:
+		try:
+			logger.info(f'Trying selector: {truncate_selector(try_selector)}')
+			locator = page.locator(try_selector)
+			await locator.wait_for(state='visible', timeout=timeout_ms)
+			logger.info(f'Found element with selector: {truncate_selector(try_selector)}')
+			return locator, try_selector
+		except Exception as e:
+			logger.error(f'Selector failed: {truncate_selector(try_selector)} with error: {e}')
 
-    # Try XPath as last resort
-    if params and getattr(params, "xpath", None):
-        xpath = params.xpath
-        try:
-            # Generate stable XPath alternatives
-            xpath_alternatives = [xpath] + generate_stable_xpaths(xpath, params)
+	# Try XPath as last resort
+	if params and getattr(params, 'xpath', None):
+		xpath = params.xpath
+		try:
+			# Generate stable XPath alternatives
+			xpath_alternatives = [xpath] + generate_stable_xpaths(xpath, params)
 
-            for try_xpath in xpath_alternatives:
-                xpath_selector = f"xpath={try_xpath}"
-                logger.info(f"Trying XPath: {truncate_selector(xpath_selector)}")
-                locator = page.locator(xpath_selector)
-                await locator.wait_for(state="visible", timeout=timeout_ms)
-                return locator, xpath_selector
-        except Exception as e:
-            logger.error(f"All XPaths failed with error: {e}")
+			for try_xpath in xpath_alternatives:
+				xpath_selector = f'xpath={try_xpath}'
+				logger.info(f'Trying XPath: {truncate_selector(xpath_selector)}')
+				locator = page.locator(xpath_selector)
+				await locator.wait_for(state='visible', timeout=timeout_ms)
+				return locator, xpath_selector
+		except Exception as e:
+			logger.error(f'All XPaths failed with error: {e}')
 
-    raise Exception(f"Failed to find element. Original: {original_selector}")
+	raise Exception(f'Failed to find element. Original: {original_selector}')
 
 
 def generate_stable_selectors(selector, params=None):
-    """Generate selectors from most to least stable based on selector patterns."""
-    fallbacks = []
+	"""Generate selectors from most to least stable based on selector patterns."""
+	fallbacks = []
 
-    # 1. Extract attribute-based selectors (most stable)
-    attributes_to_check = [
-        "placeholder",
-        "aria-label",
-        "name",
-        "title",
-        "role",
-        "data-testid",
-    ]
-    for attr in attributes_to_check:
-        attr_pattern = rf'\[{attr}\*?=[\'"]([^\'"]*)[\'"]'
-        attr_match = re.search(attr_pattern, selector)
-        if attr_match:
-            attr_value = attr_match.group(1)
-            element_tag = extract_element_tag(selector, params)
-            if element_tag:
-                fallbacks.append(f'{element_tag}[{attr}*="{attr_value}"]')
+	# 1. Extract attribute-based selectors (most stable)
+	attributes_to_check = [
+		'placeholder',
+		'aria-label',
+		'name',
+		'title',
+		'role',
+		'data-testid',
+	]
+	for attr in attributes_to_check:
+		attr_pattern = rf'\[{attr}\*?=[\'"]([^\'"]*)[\'"]'
+		attr_match = re.search(attr_pattern, selector)
+		if attr_match:
+			attr_value = attr_match.group(1)
+			element_tag = extract_element_tag(selector, params)
+			if element_tag:
+				fallbacks.append(f'{element_tag}[{attr}*="{attr_value}"]')
 
-    # 2. Combine tag + class + one attribute (good stability)
-    element_tag = extract_element_tag(selector, params)
-    classes = extract_stable_classes(selector)
-    for attr in attributes_to_check:
-        attr_pattern = rf'\[{attr}\*?=[\'"]([^\'"]*)[\'"]'
-        attr_match = re.search(attr_pattern, selector)
-        if attr_match and classes and element_tag:
-            attr_value = attr_match.group(1)
-            class_selector = ".".join(classes)
-            fallbacks.append(f'{element_tag}.{class_selector}[{attr}*="{attr_value}"]')
+	# 2. Combine tag + class + one attribute (good stability)
+	element_tag = extract_element_tag(selector, params)
+	classes = extract_stable_classes(selector)
+	for attr in attributes_to_check:
+		attr_pattern = rf'\[{attr}\*?=[\'"]([^\'"]*)[\'"]'
+		attr_match = re.search(attr_pattern, selector)
+		if attr_match and classes and element_tag:
+			attr_value = attr_match.group(1)
+			class_selector = '.'.join(classes)
+			fallbacks.append(f'{element_tag}.{class_selector}[{attr}*="{attr_value}"]')
 
-    # 3. Tag + class combination (less stable but often works)
-    if element_tag and classes:
-        class_selector = ".".join(classes)
-        fallbacks.append(f"{element_tag}.{class_selector}")
+	# 3. Tag + class combination (less stable but often works)
+	if element_tag and classes:
+		class_selector = '.'.join(classes)
+		fallbacks.append(f'{element_tag}.{class_selector}')
 
-    # 4. Remove dynamic parts (IDs, state classes)
-    if "[id=" in selector:
-        fallbacks.append(re.sub(r'\[id=[\'"].*?[\'"]\]', "", selector))
+	# 4. Remove dynamic parts (IDs, state classes)
+	if '[id=' in selector:
+		fallbacks.append(re.sub(r'\[id=[\'"].*?[\'"]\]', '', selector))
 
-    for state in [".focus-visible", ".hover", ".active", ".focus", ":focus"]:
-        if state in selector:
-            fallbacks.append(selector.replace(state, ""))
+	for state in ['.focus-visible', '.hover', '.active', '.focus', ':focus']:
+		if state in selector:
+			fallbacks.append(selector.replace(state, ''))
 
-    # 5. Use text-based selector if we have element tag and text
-    if (
-        params
-        and getattr(params, "elementTag", None)
-        and getattr(params, "elementText", None)
-        and params.elementText.strip()
-    ):
-        fallbacks.append(f"{params.elementTag}:has-text('{params.elementText}')")
+	# 5. Use text-based selector if we have element tag and text
+	if params and getattr(params, 'elementTag', None) and getattr(params, 'elementText', None) and params.elementText.strip():
+		fallbacks.append(f"{params.elementTag}:has-text('{params.elementText}')")
 
-    return list(dict.fromkeys(fallbacks))  # Remove duplicates while preserving order
+	return list(dict.fromkeys(fallbacks))  # Remove duplicates while preserving order
 
 
 def extract_element_tag(selector, params=None):
-    """Extract element tag from selector or params."""
-    # Try to get from selector first
-    tag_match = re.match(r"^([a-zA-Z][a-zA-Z0-9]*)", selector)
-    if tag_match:
-        return tag_match.group(1).lower()
+	"""Extract element tag from selector or params."""
+	# Try to get from selector first
+	tag_match = re.match(r'^([a-zA-Z][a-zA-Z0-9]*)', selector)
+	if tag_match:
+		return tag_match.group(1).lower()
 
-    # Fall back to params
-    if params and getattr(params, "elementTag", None):
-        return params.elementTag.lower()
+	# Fall back to params
+	if params and getattr(params, 'elementTag', None):
+		return params.elementTag.lower()
 
-    return ""
+	return ''
 
 
 def extract_stable_classes(selector):
-    """Extract classes that appear to be stable (not state-related)."""
-    class_pattern = r"\.([a-zA-Z0-9_-]+)"
-    classes = re.findall(class_pattern, selector)
+	"""Extract classes that appear to be stable (not state-related)."""
+	class_pattern = r'\.([a-zA-Z0-9_-]+)'
+	classes = re.findall(class_pattern, selector)
 
-    # Filter out likely state classes
-    stable_classes = [
-        cls
-        for cls in classes
-        if not any(
-            state in cls.lower()
-            for state in ["focus", "hover", "active", "selected", "checked", "disabled"]
-        )
-    ]
+	# Filter out likely state classes
+	stable_classes = [
+		cls
+		for cls in classes
+		if not any(state in cls.lower() for state in ['focus', 'hover', 'active', 'selected', 'checked', 'disabled'])
+	]
 
-    return stable_classes
+	return stable_classes
 
 
 def generate_stable_xpaths(xpath, params=None):
-    """Generate stable XPath alternatives."""
-    alternatives = []
+	"""Generate stable XPath alternatives."""
+	alternatives = []
 
-    # Handle "id()" XPath pattern which is brittle
-    if "id(" in xpath:
-        element_tag = getattr(params, "elementTag", "").lower()
-        if element_tag:
-            # Create XPaths based on attributes from params
-            if params and getattr(params, "cssSelector", None):
-                for attr in ["placeholder", "aria-label", "title", "name"]:
-                    attr_pattern = rf'\[{attr}\*?=[\'"]([^\'"]*)[\'"]'
-                    attr_match = re.search(attr_pattern, params.cssSelector)
-                    if attr_match:
-                        attr_value = attr_match.group(1)
-                        alternatives.append(
-                            f"//{element_tag}[contains(@{attr}, '{attr_value}')]"
-                        )
+	# Handle "id()" XPath pattern which is brittle
+	if 'id(' in xpath:
+		element_tag = getattr(params, 'elementTag', '').lower()
+		if element_tag:
+			# Create XPaths based on attributes from params
+			if params and getattr(params, 'cssSelector', None):
+				for attr in ['placeholder', 'aria-label', 'title', 'name']:
+					attr_pattern = rf'\[{attr}\*?=[\'"]([^\'"]*)[\'"]'
+					attr_match = re.search(attr_pattern, params.cssSelector)
+					if attr_match:
+						attr_value = attr_match.group(1)
+						alternatives.append(f"//{element_tag}[contains(@{attr}, '{attr_value}')]")
 
-    return alternatives
+	return alternatives

--- a/workflows/workflow_use/controller/views.py
+++ b/workflows/workflow_use/controller/views.py
@@ -5,70 +5,77 @@ from pydantic import BaseModel
 
 # Shared config allowing extra fields so recorder payloads pass through
 class _BaseExtra(BaseModel):
-    """Base model ignoring unknown fields."""
+	"""Base model ignoring unknown fields."""
 
-    class Config:
-        extra = "ignore"
+	class Config:
+		extra = 'ignore'
 
 
 # Mixin for shared step metadata (timestamp and tab context)
 class StepMeta(_BaseExtra):
-    timestamp: int
-    tabId: int
+	timestamp: int
+	tabId: int
 
 
 # Common optional fields present in recorder events
 class RecorderBase(StepMeta):
-    xpath: Optional[str] = None
-    elementTag: Optional[str] = None
-    elementText: Optional[str] = None
-    frameUrl: Optional[str] = None
-    screenshot: Optional[str] = None
+	xpath: Optional[str] = None
+	elementTag: Optional[str] = None
+	elementText: Optional[str] = None
+	frameUrl: Optional[str] = None
+	screenshot: Optional[str] = None
 
 
 class ClickElementDeterministicAction(RecorderBase):
-    """Parameters for clicking an element identified by CSS selector."""
+	"""Parameters for clicking an element identified by CSS selector."""
 
-    type: Literal["click"]
-    cssSelector: str
+	type: Literal['click']
+	cssSelector: str
 
 
 class InputTextDeterministicAction(RecorderBase):
-    """Parameters for entering text into an input field identified by CSS selector."""
+	"""Parameters for entering text into an input field identified by CSS selector."""
 
-    type: Literal["input"]
-    cssSelector: str
-    value: str
+	type: Literal['input']
+	cssSelector: str
+	value: str
 
 
 class SelectDropdownOptionDeterministicAction(RecorderBase):
-    """Parameters for selecting a dropdown option identified by *selector* and *text*."""
+	"""Parameters for selecting a dropdown option identified by *selector* and *text*."""
 
-    type: Literal["select_change"]
-    cssSelector: str
-    selectedValue: str
-    selectedText: str
+	type: Literal['select_change']
+	cssSelector: str
+	selectedValue: str
+	selectedText: str
 
 
 class KeyPressDeterministicAction(RecorderBase):
-    """Parameters for pressing a key on an element identified by CSS selector."""
+	"""Parameters for pressing a key on an element identified by CSS selector."""
 
-    type: Literal["key_press"]
-    cssSelector: str
-    key: str
+	type: Literal['key_press']
+	cssSelector: str
+	key: str
 
 
 class NavigationAction(_BaseExtra):
-    """Parameters for navigating to a URL."""
+	"""Parameters for navigating to a URL."""
 
-    type: Literal["navigation"]
-    url: str
+	type: Literal['navigation']
+	url: str
 
 
 class ScrollDeterministicAction(_BaseExtra):
-    """Parameters for scrolling the page by x/y offsets (pixels)."""
+	"""Parameters for scrolling the page by x/y offsets (pixels)."""
 
-    type: Literal["scroll"]
-    scrollX: int = 0
-    scrollY: int = 0
-    targetId: Optional[int] = None
+	type: Literal['scroll']
+	scrollX: int = 0
+	scrollY: int = 0
+	targetId: Optional[int] = None
+
+
+class PageExtractionAction(_BaseExtra):
+	"""Parameters for extracting content from the page."""
+
+	type: Literal['extract_page_content']
+	goal: str

--- a/workflows/workflow_use/mcp/service.py
+++ b/workflows/workflow_use/mcp/service.py
@@ -12,17 +12,20 @@ from workflow_use.workflow.service import Workflow
 
 def get_mcp_server(
 	llm_instance: BaseChatModel,
+	page_extraction_llm: BaseChatModel | None = None,
 	workflow_dir: str = './tmp',
 	name: str = 'WorkflowService',
 	description: str = 'Exposes workflows as MCP tools.',
 ):
 	mcp_app = FastMCP(name=name, description=description)
 
-	_setup_workflow_tools(mcp_app, llm_instance, workflow_dir)
+	_setup_workflow_tools(mcp_app, llm_instance, page_extraction_llm, workflow_dir)
 	return mcp_app
 
 
-def _setup_workflow_tools(mcp_app: FastMCP, llm_instance: BaseChatModel, workflow_dir: str):
+def _setup_workflow_tools(
+	mcp_app: FastMCP, llm_instance: BaseChatModel, page_extraction_llm: BaseChatModel | None, workflow_dir: str
+):
 	"""
 	Scans a directory for workflow.json files, loads them, and registers them as tools
 	with the FastMCP instance by dynamically setting function signatures.
@@ -36,7 +39,9 @@ def _setup_workflow_tools(mcp_app: FastMCP, llm_instance: BaseChatModel, workflo
 			schema = WorkflowDefinitionSchema.load_from_json(str(wf_file_path))
 
 			# Instantiate the workflow
-			workflow = Workflow(workflow_schema=schema, llm=llm_instance, browser=None, controller=None)
+			workflow = Workflow(
+				workflow_schema=schema, llm=llm_instance, page_extraction_llm=page_extraction_llm, browser=None, controller=None
+			)
 
 			params_for_signature = []
 			annotations_for_runner = {}

--- a/workflows/workflow_use/recorder/recorder.py
+++ b/workflows/workflow_use/recorder/recorder.py
@@ -5,30 +5,28 @@ from workflow_use.recorder.service import RecordingService  # Adjust import path
 
 
 async def run_recording():
-    service = RecordingService()
-    print("Starting recording session via service...")
-    workflow_schema = await service.capture_workflow()
+	service = RecordingService()
+	print('Starting recording session via service...')
+	workflow_schema = await service.capture_workflow()
 
-    if workflow_schema:
-        print("\n--- MAIN SCRIPT: CAPTURED WORKFLOW ---")
-        try:
-            print(workflow_schema.model_dump_json(indent=2))
-        except AttributeError:
-            # Fallback if model_dump_json isn't available (e.g. if it's a dict)
-            import json
+	if workflow_schema:
+		print('\n--- MAIN SCRIPT: CAPTURED WORKFLOW ---')
+		try:
+			print(workflow_schema.model_dump_json(indent=2))
+		except AttributeError:
+			# Fallback if model_dump_json isn't available (e.g. if it's a dict)
+			import json
 
-            print(
-                json.dumps(workflow_schema, indent=2)
-            )  # Ensure schema is serializable
-        print("------------------------------------")
-    else:
-        print("MAIN SCRIPT: No workflow was captured.")
+			print(json.dumps(workflow_schema, indent=2))  # Ensure schema is serializable
+		print('------------------------------------')
+	else:
+		print('MAIN SCRIPT: No workflow was captured.')
 
 
-if __name__ == "__main__":
-    try:
-        asyncio.run(run_recording())
-    except KeyboardInterrupt:
-        print("Main recording script interrupted.")
-    except Exception as e:
-        print(f"An error occurred in the main recording script: {e}")
+if __name__ == '__main__':
+	try:
+		asyncio.run(run_recording())
+	except KeyboardInterrupt:
+		print('Main recording script interrupted.')
+	except Exception as e:
+		print(f'An error occurred in the main recording script: {e}')

--- a/workflows/workflow_use/recorder/service.py
+++ b/workflows/workflow_use/recorder/service.py
@@ -4,7 +4,7 @@ import pathlib
 from typing import Optional
 
 import uvicorn
-from fastapi import FastAPI, Request
+from fastapi import FastAPI
 from playwright.async_api import BrowserContext, async_playwright
 
 # Assuming views.py is correctly located for this import path

--- a/workflows/workflow_use/recorder/service.py
+++ b/workflows/workflow_use/recorder/service.py
@@ -9,277 +9,236 @@ from playwright.async_api import BrowserContext, async_playwright
 
 # Assuming views.py is correctly located for this import path
 from workflow_use.recorder.views import (
-    HttpRecordingStoppedEvent,
-    HttpWorkflowUpdateEvent,
-    RecorderEvent,
-    WorkflowDefinitionSchema,  # This is the expected output type
+	HttpRecordingStoppedEvent,
+	HttpWorkflowUpdateEvent,
+	RecorderEvent,
+	WorkflowDefinitionSchema,  # This is the expected output type
 )
 
 # Path Configuration (should be identical to recorder.py if run from the same context)
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
-EXT_DIR = SCRIPT_DIR.parent.parent.parent / "extension" / ".output" / "chrome-mv3"
-USER_DATA_DIR = SCRIPT_DIR / "user_data_dir"
+EXT_DIR = SCRIPT_DIR.parent.parent.parent / 'extension' / '.output' / 'chrome-mv3'
+USER_DATA_DIR = SCRIPT_DIR / 'user_data_dir'
 
 
 class RecordingService:
-    def __init__(self):
-        self.event_queue: asyncio.Queue[RecorderEvent] = asyncio.Queue()
-        self.last_workflow_update_event: Optional[HttpWorkflowUpdateEvent] = None
-        self.playwright_context: Optional[BrowserContext] = None
+	def __init__(self):
+		self.event_queue: asyncio.Queue[RecorderEvent] = asyncio.Queue()
+		self.last_workflow_update_event: Optional[HttpWorkflowUpdateEvent] = None
+		self.playwright_context: Optional[BrowserContext] = None
 
-        self.final_workflow_output: Optional[WorkflowDefinitionSchema] = None
-        self.recording_complete_event = asyncio.Event()
-        self.final_workflow_processed_lock = asyncio.Lock()
-        self.final_workflow_processed_flag = False
+		self.final_workflow_output: Optional[WorkflowDefinitionSchema] = None
+		self.recording_complete_event = asyncio.Event()
+		self.final_workflow_processed_lock = asyncio.Lock()
+		self.final_workflow_processed_flag = False
 
-        self.app = FastAPI(title="Temporary Recording Event Server")
-        self.app.add_api_route(
-            "/event", self._handle_event_post, methods=["POST"], status_code=202
-        )
-        # -- DEBUGGING --
-        # Turn this on to debug requests
-        # @self.app.middleware("http")
-        # async def log_requests(request: Request, call_next):
-        #     print(f"[Debug] Incoming request: {request.method} {request.url}")
-        #     try:
-        #         # Read request body
-        #         body = await request.body()
-        #         print(f"[Debug] Request body: {body.decode('utf-8', errors='replace')}")
-        #         response = await call_next(request)
-        #         print(f"[Debug] Response status: {response.status_code}")
-        #         return response
-        #     except Exception as e:
-        #         print(f"[Error] Error processing request: {str(e)}")
+		self.app = FastAPI(title='Temporary Recording Event Server')
+		self.app.add_api_route('/event', self._handle_event_post, methods=['POST'], status_code=202)
+		# -- DEBUGGING --
+		# Turn this on to debug requests
+		# @self.app.middleware("http")
+		# async def log_requests(request: Request, call_next):
+		#     print(f"[Debug] Incoming request: {request.method} {request.url}")
+		#     try:
+		#         # Read request body
+		#         body = await request.body()
+		#         print(f"[Debug] Request body: {body.decode('utf-8', errors='replace')}")
+		#         response = await call_next(request)
+		#         print(f"[Debug] Response status: {response.status_code}")
+		#         return response
+		#     except Exception as e:
+		#         print(f"[Error] Error processing request: {str(e)}")
 
-        self.uvicorn_server_instance: Optional[uvicorn.Server] = None
-        self.server_task: Optional[asyncio.Task] = None
-        self.playwright_task: Optional[asyncio.Task] = None
-        self.event_processor_task: Optional[asyncio.Task] = None
+		self.uvicorn_server_instance: Optional[uvicorn.Server] = None
+		self.server_task: Optional[asyncio.Task] = None
+		self.playwright_task: Optional[asyncio.Task] = None
+		self.event_processor_task: Optional[asyncio.Task] = None
 
-    async def _handle_event_post(self, event_data: RecorderEvent):
-        if isinstance(event_data, HttpWorkflowUpdateEvent):
-            self.last_workflow_update_event = event_data
-        await self.event_queue.put(event_data)
-        return {"status": "accepted", "message": "Event queued for processing"}
+	async def _handle_event_post(self, event_data: RecorderEvent):
+		if isinstance(event_data, HttpWorkflowUpdateEvent):
+			self.last_workflow_update_event = event_data
+		await self.event_queue.put(event_data)
+		return {'status': 'accepted', 'message': 'Event queued for processing'}
 
-    async def _process_event_queue(self):
-        print("[Service] Event processing task started.")
-        try:
-            while True:
-                event = await self.event_queue.get()
-                print(f"[Service] Event Received: {event.type}")
-                if isinstance(event, HttpWorkflowUpdateEvent):
-                    # self.last_workflow_update_event is already updated in _handle_event_post
-                    pass
-                elif isinstance(event, HttpRecordingStoppedEvent):
-                    print(
-                        "[Service] RecordingStoppedEvent received, processing final workflow..."
-                    )
-                    await self._capture_and_signal_final_workflow(
-                        "RecordingStoppedEvent"
-                    )
-                self.event_queue.task_done()
-        except asyncio.CancelledError:
-            print("[Service] Event processing task cancelled.")
-        except Exception as e:
-            print(f"[Service] Error in event processing task: {e}")
+	async def _process_event_queue(self):
+		print('[Service] Event processing task started.')
+		try:
+			while True:
+				event = await self.event_queue.get()
+				print(f'[Service] Event Received: {event.type}')
+				if isinstance(event, HttpWorkflowUpdateEvent):
+					# self.last_workflow_update_event is already updated in _handle_event_post
+					pass
+				elif isinstance(event, HttpRecordingStoppedEvent):
+					print('[Service] RecordingStoppedEvent received, processing final workflow...')
+					await self._capture_and_signal_final_workflow('RecordingStoppedEvent')
+				self.event_queue.task_done()
+		except asyncio.CancelledError:
+			print('[Service] Event processing task cancelled.')
+		except Exception as e:
+			print(f'[Service] Error in event processing task: {e}')
 
-    async def _capture_and_signal_final_workflow(self, trigger_reason: str):
-        processed_this_call = False
-        async with self.final_workflow_processed_lock:
-            if (
-                not self.final_workflow_processed_flag
-                and self.last_workflow_update_event
-            ):
-                print(
-                    f"[Service] Capturing final workflow (Trigger: {trigger_reason})."
-                )
-                self.final_workflow_output = self.last_workflow_update_event.payload
-                self.final_workflow_processed_flag = True
-                processed_this_call = True
+	async def _capture_and_signal_final_workflow(self, trigger_reason: str):
+		processed_this_call = False
+		async with self.final_workflow_processed_lock:
+			if not self.final_workflow_processed_flag and self.last_workflow_update_event:
+				print(f'[Service] Capturing final workflow (Trigger: {trigger_reason}).')
+				self.final_workflow_output = self.last_workflow_update_event.payload
+				self.final_workflow_processed_flag = True
+				processed_this_call = True
 
-        if processed_this_call:
-            print(
-                "[Service] Final workflow captured. Setting recording_complete_event."
-            )
-            self.recording_complete_event.set()  # Signal completion to the main method
+		if processed_this_call:
+			print('[Service] Final workflow captured. Setting recording_complete_event.')
+			self.recording_complete_event.set()  # Signal completion to the main method
 
-            # If processing was due to RecordingStoppedEvent, also try to close the browser
-            if trigger_reason == "RecordingStoppedEvent" and self.playwright_context:
-                print(
-                    "[Service] Attempting to close Playwright browser due to RecordingStoppedEvent..."
-                )
-                try:
-                    await self.playwright_context.close()
-                    print("[Service] Playwright browser close command issued.")
-                except Exception as e_close:
-                    print(
-                        f"[Service] Error closing Playwright browser on recording stop: {e_close}"
-                    )
+			# If processing was due to RecordingStoppedEvent, also try to close the browser
+			if trigger_reason == 'RecordingStoppedEvent' and self.playwright_context:
+				print('[Service] Attempting to close Playwright browser due to RecordingStoppedEvent...')
+				try:
+					await self.playwright_context.close()
+					print('[Service] Playwright browser close command issued.')
+				except Exception as e_close:
+					print(f'[Service] Error closing Playwright browser on recording stop: {e_close}')
 
-    async def _launch_playwright_and_wait(self):
-        print(f"[Service] Attempting to load extension from: {EXT_DIR}")
-        if not EXT_DIR.exists() or not EXT_DIR.is_dir():
-            print(f"[Service] ERROR: Extension directory not found: {EXT_DIR}")
-            self.recording_complete_event.set()  # Signal failure
-            return
+	async def _launch_playwright_and_wait(self):
+		print(f'[Service] Attempting to load extension from: {EXT_DIR}')
+		if not EXT_DIR.exists() or not EXT_DIR.is_dir():
+			print(f'[Service] ERROR: Extension directory not found: {EXT_DIR}')
+			self.recording_complete_event.set()  # Signal failure
+			return
 
-        # delete the user data dir
-        USER_DATA_DIR.mkdir(parents=True, exist_ok=True)
-        print(f"[Service] Using Playwright user data directory: {USER_DATA_DIR}")
+		# delete the user data dir
+		USER_DATA_DIR.mkdir(parents=True, exist_ok=True)
+		print(f'[Service] Using Playwright user data directory: {USER_DATA_DIR}')
 
-        async with async_playwright() as p:
-            try:
-                self.playwright_context = await p.chromium.launch_persistent_context(
-                    str(USER_DATA_DIR.resolve()),
-                    headless=False,
-                    no_viewport=True,
-                    args=[
-                        f"--disable-extensions-except={str(EXT_DIR.resolve())}",
-                        f"--load-extension={str(EXT_DIR.resolve())}",
-                    ],
-                )
-                print(
-                    "[Service] Playwright browser launched. Waiting for close or recording stop..."
-                )
-                await self.playwright_context.wait_for_event("close", timeout=0)
-                print("[Service] Playwright context 'close' event detected.")
-            except asyncio.CancelledError:
-                print("[Service] Playwright task cancelled.")
-                if self.playwright_context:
-                    try:
-                        await self.playwright_context.close()
-                    except:
-                        pass  # Best effort
-                raise  # Re-raise to be caught by gather
-            except Exception as e:
-                print(f"[Service] Error in Playwright task: {e}")
-            finally:
-                print("[Service] Playwright task finalization.")
-                self.playwright_context = None
-                # This call ensures that if browser is closed manually, we still try to capture.
-                await self._capture_and_signal_final_workflow("PlaywrightTaskEnded")
+		async with async_playwright() as p:
+			try:
+				self.playwright_context = await p.chromium.launch_persistent_context(
+					str(USER_DATA_DIR.resolve()),
+					headless=False,
+					no_viewport=True,
+					args=[
+						f'--disable-extensions-except={str(EXT_DIR.resolve())}',
+						f'--load-extension={str(EXT_DIR.resolve())}',
+					],
+				)
+				print('[Service] Playwright browser launched. Waiting for close or recording stop...')
+				await self.playwright_context.wait_for_event('close', timeout=0)
+				print("[Service] Playwright context 'close' event detected.")
+			except asyncio.CancelledError:
+				print('[Service] Playwright task cancelled.')
+				if self.playwright_context:
+					try:
+						await self.playwright_context.close()
+					except:
+						pass  # Best effort
+				raise  # Re-raise to be caught by gather
+			except Exception as e:
+				print(f'[Service] Error in Playwright task: {e}')
+			finally:
+				print('[Service] Playwright task finalization.')
+				self.playwright_context = None
+				# This call ensures that if browser is closed manually, we still try to capture.
+				await self._capture_and_signal_final_workflow('PlaywrightTaskEnded')
 
-    async def capture_workflow(self) -> Optional[WorkflowDefinitionSchema]:
-        print("[Service] Starting capture_workflow session...")
-        # Reset state for this session
-        self.last_workflow_update_event = None
-        self.final_workflow_output = None
-        self.recording_complete_event.clear()
-        self.final_workflow_processed_flag = False
+	async def capture_workflow(self) -> Optional[WorkflowDefinitionSchema]:
+		print('[Service] Starting capture_workflow session...')
+		# Reset state for this session
+		self.last_workflow_update_event = None
+		self.final_workflow_output = None
+		self.recording_complete_event.clear()
+		self.final_workflow_processed_flag = False
 
-        # Start background tasks
-        self.event_processor_task = asyncio.create_task(self._process_event_queue())
-        self.playwright_task = asyncio.create_task(self._launch_playwright_and_wait())
+		# Start background tasks
+		self.event_processor_task = asyncio.create_task(self._process_event_queue())
+		self.playwright_task = asyncio.create_task(self._launch_playwright_and_wait())
 
-        # Configure and start Uvicorn server
-        config = uvicorn.Config(
-            self.app, host="127.0.0.1", port=7331, log_level="warning", loop="asyncio"
-        )
-        self.uvicorn_server_instance = uvicorn.Server(config)
-        self.server_task = asyncio.create_task(self.uvicorn_server_instance.serve())
-        print("[Service] Uvicorn server task started.")
+		# Configure and start Uvicorn server
+		config = uvicorn.Config(self.app, host='127.0.0.1', port=7331, log_level='warning', loop='asyncio')
+		self.uvicorn_server_instance = uvicorn.Server(config)
+		self.server_task = asyncio.create_task(self.uvicorn_server_instance.serve())
+		print('[Service] Uvicorn server task started.')
 
-        try:
-            print("[Service] Waiting for recording to complete...")
-            await self.recording_complete_event.wait()
-            print("[Service] Recording complete event received. Proceeding to cleanup.")
-        except asyncio.CancelledError:
-            print("[Service] capture_workflow task was cancelled externally.")
-        finally:
-            print("[Service] Starting cleanup phase...")
+		try:
+			print('[Service] Waiting for recording to complete...')
+			await self.recording_complete_event.wait()
+			print('[Service] Recording complete event received. Proceeding to cleanup.')
+		except asyncio.CancelledError:
+			print('[Service] capture_workflow task was cancelled externally.')
+		finally:
+			print('[Service] Starting cleanup phase...')
 
-            # 1. Stop Uvicorn server
-            if (
-                self.uvicorn_server_instance
-                and self.server_task
-                and not self.server_task.done()
-            ):
-                print("[Service] Signaling Uvicorn server to shut down...")
-                self.uvicorn_server_instance.should_exit = True
-                try:
-                    await asyncio.wait_for(
-                        self.server_task, timeout=5
-                    )  # Give server time to shut down
-                except asyncio.TimeoutError:
-                    print(
-                        "[Service] Uvicorn server shutdown timed out. Cancelling task."
-                    )
-                    self.server_task.cancel()
-                except (
-                    asyncio.CancelledError
-                ):  # If capture_workflow itself was cancelled
-                    pass
-                except Exception as e_server_shutdown:
-                    print(
-                        f"[Service] Error during Uvicorn server shutdown: {e_server_shutdown}"
-                    )
+			# 1. Stop Uvicorn server
+			if self.uvicorn_server_instance and self.server_task and not self.server_task.done():
+				print('[Service] Signaling Uvicorn server to shut down...')
+				self.uvicorn_server_instance.should_exit = True
+				try:
+					await asyncio.wait_for(self.server_task, timeout=5)  # Give server time to shut down
+				except asyncio.TimeoutError:
+					print('[Service] Uvicorn server shutdown timed out. Cancelling task.')
+					self.server_task.cancel()
+				except asyncio.CancelledError:  # If capture_workflow itself was cancelled
+					pass
+				except Exception as e_server_shutdown:
+					print(f'[Service] Error during Uvicorn server shutdown: {e_server_shutdown}')
 
-            # 2. Stop Playwright task (and ensure browser is closed)
-            if self.playwright_task and not self.playwright_task.done():
-                print("[Service] Cancelling Playwright task...")
-                self.playwright_task.cancel()
-                try:
-                    await self.playwright_task
-                except asyncio.CancelledError:
-                    pass
-                except Exception as e_pw_cancel:
-                    print(
-                        f"[Service] Error awaiting cancelled Playwright task: {e_pw_cancel}"
-                    )
+			# 2. Stop Playwright task (and ensure browser is closed)
+			if self.playwright_task and not self.playwright_task.done():
+				print('[Service] Cancelling Playwright task...')
+				self.playwright_task.cancel()
+				try:
+					await self.playwright_task
+				except asyncio.CancelledError:
+					pass
+				except Exception as e_pw_cancel:
+					print(f'[Service] Error awaiting cancelled Playwright task: {e_pw_cancel}')
 
-            if self.playwright_context:  # Final check to close context if still open
-                print("[Service] Ensuring Playwright context is closed in cleanup...")
-                try:
-                    await self.playwright_context.close()
-                except Exception as e_pc_close:
-                    print(
-                        f"[Service] Error closing context in final cleanup: {e_pc_close}"
-                    )
-                self.playwright_context = None
+			if self.playwright_context:  # Final check to close context if still open
+				print('[Service] Ensuring Playwright context is closed in cleanup...')
+				try:
+					await self.playwright_context.close()
+				except Exception as e_pc_close:
+					print(f'[Service] Error closing context in final cleanup: {e_pc_close}')
+				self.playwright_context = None
 
-            # 3. Stop event processor task
-            if self.event_processor_task and not self.event_processor_task.done():
-                print("[Service] Cancelling event processor task...")
-                self.event_processor_task.cancel()
-                try:
-                    await self.event_processor_task
-                except asyncio.CancelledError:
-                    pass
-                except Exception as e_ep_cancel:
-                    print(
-                        f"[Service] Error awaiting cancelled event processor task: {e_ep_cancel}"
-                    )
+			# 3. Stop event processor task
+			if self.event_processor_task and not self.event_processor_task.done():
+				print('[Service] Cancelling event processor task...')
+				self.event_processor_task.cancel()
+				try:
+					await self.event_processor_task
+				except asyncio.CancelledError:
+					pass
+				except Exception as e_ep_cancel:
+					print(f'[Service] Error awaiting cancelled event processor task: {e_ep_cancel}')
 
-            print("[Service] Cleanup phase complete.")
+			print('[Service] Cleanup phase complete.')
 
-        if self.final_workflow_output:
-            print("[Service] Returning captured workflow.")
-        else:
-            print("[Service] No workflow captured or an error occurred.")
-        return self.final_workflow_output
+		if self.final_workflow_output:
+			print('[Service] Returning captured workflow.')
+		else:
+			print('[Service] No workflow captured or an error occurred.')
+		return self.final_workflow_output
 
 
 async def main_service_runner():  # Example of how to run the service
-    service = RecordingService()
-    workflow_data = await service.capture_workflow()
-    if workflow_data:
-        print("\n--- CAPTURED WORKFLOW DATA (from main_service_runner) ---")
-        # Assuming WorkflowDefinitionSchema has model_dump_json or similar
-        try:
-            print(workflow_data.model_dump_json(indent=2))
-        except AttributeError:
-            print(
-                json.dumps(workflow_data, indent=2)
-            )  # Fallback for plain dicts if model_dump_json not present
-        print("-----------------------------------------------------")
-    else:
-        print("No workflow data was captured by the service.")
+	service = RecordingService()
+	workflow_data = await service.capture_workflow()
+	if workflow_data:
+		print('\n--- CAPTURED WORKFLOW DATA (from main_service_runner) ---')
+		# Assuming WorkflowDefinitionSchema has model_dump_json or similar
+		try:
+			print(workflow_data.model_dump_json(indent=2))
+		except AttributeError:
+			print(json.dumps(workflow_data, indent=2))  # Fallback for plain dicts if model_dump_json not present
+		print('-----------------------------------------------------')
+	else:
+		print('No workflow data was captured by the service.')
 
 
-if __name__ == "__main__":
-    # This allows running service.py directly for testing
-    try:
-        asyncio.run(main_service_runner())
-    except KeyboardInterrupt:
-        print("Service runner interrupted by user.")
+if __name__ == '__main__':
+	# This allows running service.py directly for testing
+	try:
+		asyncio.run(main_service_runner())
+	except KeyboardInterrupt:
+		print('Service runner interrupted by user.')

--- a/workflows/workflow_use/recorder/views.py
+++ b/workflows/workflow_use/recorder/views.py
@@ -8,34 +8,34 @@ from workflow_use.schema.views import WorkflowDefinitionSchema
 
 
 class RecordingStatusPayload(BaseModel):
-    message: str
+	message: str
 
 
 # --- Main Event Models (mirroring HttpEvent types from message-bus-types.ts) ---
 
 
 class BaseHttpEvent(BaseModel):
-    timestamp: int
+	timestamp: int
 
 
 class HttpWorkflowUpdateEvent(BaseHttpEvent):
-    type: Literal["WORKFLOW_UPDATE"] = "WORKFLOW_UPDATE"
-    payload: WorkflowDefinitionSchema
+	type: Literal['WORKFLOW_UPDATE'] = 'WORKFLOW_UPDATE'
+	payload: WorkflowDefinitionSchema
 
 
 class HttpRecordingStartedEvent(BaseHttpEvent):
-    type: Literal["RECORDING_STARTED"] = "RECORDING_STARTED"
-    payload: RecordingStatusPayload
+	type: Literal['RECORDING_STARTED'] = 'RECORDING_STARTED'
+	payload: RecordingStatusPayload
 
 
 class HttpRecordingStoppedEvent(BaseHttpEvent):
-    type: Literal["RECORDING_STOPPED"] = "RECORDING_STOPPED"
-    payload: RecordingStatusPayload
+	type: Literal['RECORDING_STOPPED'] = 'RECORDING_STOPPED'
+	payload: RecordingStatusPayload
 
 
 # Union of all possible event types received by the recorder
 RecorderEvent = Union[
-    HttpWorkflowUpdateEvent,
-    HttpRecordingStartedEvent,
-    HttpRecordingStoppedEvent,
+	HttpWorkflowUpdateEvent,
+	HttpRecordingStartedEvent,
+	HttpRecordingStoppedEvent,
 ]

--- a/workflows/workflow_use/schema/views.py
+++ b/workflows/workflow_use/schema/views.py
@@ -88,6 +88,13 @@ class ScrollStep(TimestampedWorkflowStep):
 	scrollY: int = Field(..., description='Vertical scroll pixels.')
 
 
+class PageExtractionStep(TimestampedWorkflowStep):
+	"""Extracts text from the page using 'page_extraction' (maps to workflow controller's page_extraction)."""
+
+	type: Literal['page_extraction']  # Assumed type for workflow controller's page_extraction
+	goal: str = Field(..., description='The goal of the page extraction.')
+
+
 # --- Union of all possible step types ---
 # This Union defines what constitutes a valid step in the "steps" list.
 DeterministicWorkflowStep = Union[

--- a/workflows/workflow_use/schema/views.py
+++ b/workflows/workflow_use/schema/views.py
@@ -91,7 +91,7 @@ class ScrollStep(TimestampedWorkflowStep):
 class PageExtractionStep(TimestampedWorkflowStep):
 	"""Extracts text from the page using 'page_extraction' (maps to workflow controller's page_extraction)."""
 
-	type: Literal['page_extraction']  # Assumed type for workflow controller's page_extraction
+	type: Literal['extract_page_content']  # Assumed type for workflow controller's page_extraction
 	goal: str = Field(..., description='The goal of the page extraction.')
 
 
@@ -104,6 +104,7 @@ DeterministicWorkflowStep = Union[
 	SelectChangeStep,
 	KeyPressStep,
 	ScrollStep,
+	PageExtractionStep,
 ]
 
 AgenticWorkflowStep = AgentTaskWorkflowStep

--- a/workflows/workflow_use/workflow/prompts.py
+++ b/workflows/workflow_use/workflow/prompts.py
@@ -1,16 +1,31 @@
 WORKFLOW_FALLBACK_PROMPT_TEMPLATE = (
-    "While executing step {step_index}/{total_steps} in the workflow:\n\n"
-    # "{workflow_details}\n\n"
-    "The deterministic action '{action_type}' failed with the following context:\n"
-    "{fail_details}\n\n"
-    "The intended target or expected value for this step was: {failed_value}\n\n"
-    "IMPORTANT: Your task is to ONLY complete this specific step ({step_index}) and nothing more. "
-    "The step's purpose is described as: '{step_description}'.\n"
-    "Do not retry the same action that failed. Instead, choose a different suitable action(s) to accomplish the same goal. "
-    "For example, if a click failed, consider navigating to a URL, inputting text, or selecting an option. "
-    "However, ONLY perform the minimum action needed to complete this specific step. "
-    "If the step requires clicking a button, ONLY click that button. If it requires navigation, ONLY navigate. "
-    "Do not perform any additional actions beyond what is strictly necessary for this step. "
-    "Once the objective of step {step_index} is reached, call the Done action to complete the step. "
-    "Do not proceed to the next step or perform any actions beyond this specific step."
+	'While executing step {step_index}/{total_steps} in the workflow:\n\n'
+	# "{workflow_details}\n\n"
+	"The deterministic action '{action_type}' failed with the following context:\n"
+	'{fail_details}\n\n'
+	'The intended target or expected value for this step was: {failed_value}\n\n'
+	'IMPORTANT: Your task is to ONLY complete this specific step ({step_index}) and nothing more. '
+	"The step's purpose is described as: '{step_description}'.\n"
+	'Do not retry the same action that failed. Instead, choose a different suitable action(s) to accomplish the same goal. '
+	'For example, if a click failed, consider navigating to a URL, inputting text, or selecting an option. '
+	'However, ONLY perform the minimum action needed to complete this specific step. '
+	'If the step requires clicking a button, ONLY click that button. If it requires navigation, ONLY navigate. '
+	'Do not perform any additional actions beyond what is strictly necessary for this step. '
+	'Once the objective of step {step_index} is reached, call the Done action to complete the step. '
+	'Do not proceed to the next step or perform any actions beyond this specific step.'
 )
+
+STRUCTURED_OUTPUT_PROMPT = """
+You are a data extraction expert. Your task is to extract structured information from the provided content.
+
+The content may contain various pieces of information from different sources. You need to analyze this content 
+and extract the relevant information according to the output schema provided below.
+
+Output Schema:
+{output_schema}
+
+Only extract information that is explicitly present in the content. If the required information is not available, 
+use reasonable default values or indicate that the information is missing.
+
+Be precise and follow the schema exactly.
+"""

--- a/workflows/workflow_use/workflow/prompts.py
+++ b/workflows/workflow_use/workflow/prompts.py
@@ -18,14 +18,7 @@ WORKFLOW_FALLBACK_PROMPT_TEMPLATE = (
 STRUCTURED_OUTPUT_PROMPT = """
 You are a data extraction expert. Your task is to extract structured information from the provided content.
 
-The content may contain various pieces of information from different sources. You need to analyze this content 
-and extract the relevant information according to the output schema provided below.
+The content may contain various pieces of information from different sources. You need to analyze this content and extract the relevant information according to the output schema provided below.
 
-Output Schema:
-{output_schema}
-
-Only extract information that is explicitly present in the content. If the required information is not available, 
-use reasonable default values or indicate that the information is missing.
-
-Be precise and follow the schema exactly.
+Only extract information that is explicitly present in the content. Be precise and follow the schema exactly.
 """

--- a/workflows/workflow_use/workflow/tests/test_extract.py
+++ b/workflows/workflow_use/workflow/tests/test_extract.py
@@ -1,0 +1,34 @@
+import asyncio
+from pathlib import Path
+
+# Ensure langchain-openai is installed and OPENAI_API_KEY is set
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel
+
+from workflow_use.workflow.service import Workflow
+
+# Instantiate the LLM and the service directly
+llm_instance = ChatOpenAI(model='gpt-4o')  # Or your preferred model
+page_extraction_llm = ChatOpenAI(model='gpt-4o-mini')
+
+
+class OutputModel(BaseModel):
+	api_key: str
+
+
+async def test_run_workflow():
+	"""
+	Tests that the workflow is built correctly from a JSON file path.
+	"""
+	path = Path(__file__).parent / 'tmp' / 'extract.workflow.json'
+
+	workflow = Workflow.load_from_file(path, llm=llm_instance, page_extraction_llm=page_extraction_llm)
+	result = await workflow.run({'api_key_name': 'test key'}, output_model=OutputModel)
+
+	assert result.output_model is not None
+
+	print(result.output_model.api_key)
+
+
+if __name__ == '__main__':
+	asyncio.run(test_run_workflow())

--- a/workflows/workflow_use/workflow/tests/test_extract.py
+++ b/workflows/workflow_use/workflow/tests/test_extract.py
@@ -23,6 +23,7 @@ async def test_run_workflow():
 	path = Path(__file__).parent / 'tmp' / 'extract.workflow.json'
 
 	workflow = Workflow.load_from_file(path, llm=llm_instance, page_extraction_llm=page_extraction_llm)
+
 	result = await workflow.run({'api_key_name': 'test key'}, output_model=OutputModel)
 
 	assert result.output_model is not None

--- a/workflows/workflow_use/workflow/views.py
+++ b/workflows/workflow_use/workflow/views.py
@@ -1,0 +1,10 @@
+from typing import List
+
+from browser_use.agent.views import ActionResult, AgentHistoryList
+from pydantic import BaseModel
+
+
+class WorkflowRunOutput(BaseModel):
+	"""Output of a workflow run"""
+
+	step_results: List[ActionResult | AgentHistoryList]

--- a/workflows/workflow_use/workflow/views.py
+++ b/workflows/workflow_use/workflow/views.py
@@ -1,10 +1,27 @@
-from typing import List
+from typing import Any, Dict, Generic, List, Optional, TypeVar
 
 from browser_use.agent.views import ActionResult, AgentHistoryList
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+T = TypeVar('T', bound=BaseModel)
 
 
-class WorkflowRunOutput(BaseModel):
+class WorkflowRunOutput(BaseModel, Generic[T]):
 	"""Output of a workflow run"""
 
 	step_results: List[ActionResult | AgentHistoryList]
+	output_model: Optional[T] = None
+
+
+class StructuredWorkflowOutput(BaseModel):
+	"""Base model for structured workflow outputs.
+
+	This can be used as a parent class for custom output models that
+	will be filled by convert_results_to_output_model method.
+	"""
+
+	raw_data: Dict[str, Any] = Field(default_factory=dict, description='Raw extracted data from workflow execution')
+
+	status: str = Field(default='success', description='Overall status of the workflow execution')
+
+	error_message: Optional[str] = Field(default=None, description='Error message if the workflow failed')


### PR DESCRIPTION
Running the workflow can now now yield

```python
result: OutputModel = await workflow.run({'api_key_name': 'test key'}, output_model=OutputModel)
```

where the result is in whatever format you want. One has to be super careful that the workflow has extractions steps, otherwise this will not work as wanted.