### PR TITLE
added bu model support

### DIFF
--- a/workflows/backend/service.py
+++ b/workflows/backend/service.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional, Tuple
 
 import aiofiles
 from browser_use.browser.browser import Browser
-from browser_use.llm import ChatOpenAI
+from browser_use.llm import ChatBrowserUse
 
 from workflow_use.controller.service import WorkflowController
 from workflow_use.workflow.service import Workflow
@@ -32,7 +32,7 @@ class WorkflowService:
 		self.log_dir.mkdir(exist_ok=True, parents=True)
 
 		# LLM / workflow executor
-		self.llm_instance = ChatOpenAI(model='gpt-4.1-mini')
+		self.llm_instance = ChatBrowserUse(model='bu-latest')
 
 		self.browser_instance = Browser()
 		self.controller_instance = WorkflowController()

--- a/workflows/cli.py
+++ b/workflows/cli.py
@@ -10,7 +10,7 @@ import aiofiles
 import pandas as pd
 import typer
 from browser_use import Browser
-from browser_use.llm import ChatOpenAI
+from browser_use.llm import ChatBrowserUse
 from browser_use.llm.base import BaseChatModel
 
 from workflow_use.builder.service import BuilderService
@@ -34,15 +34,15 @@ app = typer.Typer(
 # Default LLM instance to None
 llm_instance: BaseChatModel
 try:
-	llm_instance = ChatOpenAI(model='gpt-4.1-mini')
-	page_extraction_llm = ChatOpenAI(model='gpt-4.1-mini')
+	llm_instance = ChatBrowserUse(model='bu-latest')
+	page_extraction_llm = ChatBrowserUse(model='bu-latest')
 except Exception as e:
-	typer.secho(f'Error initializing LLM: {e}. Would you like to set your OPENAI_API_KEY?', fg=typer.colors.RED)
-	set_openai_api_key = input('Set OPENAI_API_KEY? (y/n): ')
-	if set_openai_api_key.lower() == 'y':
-		os.environ['OPENAI_API_KEY'] = input('Enter your OPENAI_API_KEY: ')
-		llm_instance = ChatOpenAI(model='gpt-4.1')
-		page_extraction_llm = ChatOpenAI(model='gpt-4.1-mini')
+	typer.secho(f'Error initializing LLM: {e}. Would you like to set your BROWSER_USE_API_KEY?', fg=typer.colors.RED)
+	set_browser_use_api_key = input('Set BROWSER_USE_API_KEY? (y/n): ')
+	if set_browser_use_api_key.lower() == 'y':
+		os.environ['BROWSER_USE_API_KEY'] = input('Enter your BROWSER_USE_API_KEY: ')
+		llm_instance = ChatBrowserUse(model='bu-latest')
+		page_extraction_llm = ChatBrowserUse(model='bu-latest')
 
 builder_service = BuilderService(llm=llm_instance) if llm_instance else None
 # recorder_service = RecorderService() # Placeholder
@@ -1324,11 +1324,11 @@ def run_workflow_no_ai_command(
 			extraction_llm = None
 
 			try:
-				from browser_use.llm import ChatOpenAI
+				from browser_use.llm import ChatBrowserUse
 
-				dummy_llm = ChatOpenAI(model='gpt-4.1-mini')
+				dummy_llm = ChatBrowserUse(model='bu-latest')
 				if enable_extraction:
-					extraction_llm = ChatOpenAI(model='gpt-4.1-mini')
+					extraction_llm = ChatBrowserUse(model='bu-latest')
 					typer.secho('AI extraction enabled - will use LLM for extraction steps only.', fg=typer.colors.BLUE)
 			except Exception as e:
 				if enable_extraction:
@@ -2071,8 +2071,8 @@ def mcp_server_command(
 	typer.echo(typer.style('Starting MCP server...', bold=True))
 	typer.echo()  # Add space
 
-	llm_instance = ChatOpenAI(model='gpt-4.1')
-	page_extraction_llm = ChatOpenAI(model='gpt-4.1-mini')
+	llm_instance = ChatBrowserUse(model='bu-latest')
+	page_extraction_llm = ChatBrowserUse(model='bu-latest')
 
 	mcp = get_mcp_server(llm_instance, page_extraction_llm=page_extraction_llm, workflow_dir='./tmp')
 
@@ -2257,8 +2257,8 @@ def generate_workflow_from_task(
 	typer.echo()
 
 	# Initialize LLMs
-	agent_llm = ChatOpenAI(model=agent_model)
-	extraction_llm = ChatOpenAI(model=extraction_model)
+	agent_llm = ChatBrowserUse(model='bu-latest')
+	extraction_llm = ChatBrowserUse(model='bu-latest')
 
 	typer.echo('Starting browser automation to complete the task...')
 	typer.echo(f'  Agent Model: {agent_model}')

--- a/workflows/examples/scripts/demos/cloud_browser_demo.py
+++ b/workflows/examples/scripts/demos/cloud_browser_demo.py
@@ -13,12 +13,12 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use.llm import ChatOpenAI
+from browser_use.llm import ChatBrowserUse
 
 from workflow_use.workflow.service import Workflow
 
 # Dummy LLM (not used in run_with_no_ai)
-llm = ChatOpenAI(model='gpt-4.1-mini')
+llm = ChatBrowserUse(model='bu-latest')
 
 
 async def main():

--- a/workflows/examples/scripts/demos/generation_mode_demo.py
+++ b/workflows/examples/scripts/demos/generation_mode_demo.py
@@ -10,7 +10,7 @@ This demonstrates:
 import asyncio
 import os
 
-from browser_use.llm import ChatOpenAI
+from browser_use.llm import ChatBrowserUse
 
 from workflow_use.healing.service import HealingService
 from workflow_use.storage.service import WorkflowStorageService
@@ -32,9 +32,9 @@ async def demo_generate_and_run():
 
 	# Initialize services
 	print('📦 Initializing services...')
-	agent_llm = ChatOpenAI(model='gpt-4.1-mini')
-	extraction_llm = ChatOpenAI(model='gpt-4.1-mini')
-	workflow_llm = ChatOpenAI(model='gpt-4.1')
+	agent_llm = ChatBrowserUse(model='bu-latest')
+	extraction_llm = ChatBrowserUse(model='bu-latest')
+	workflow_llm = ChatBrowserUse(model='bu-latest')
 
 	healing_service = HealingService(llm=workflow_llm)
 	storage_service = WorkflowStorageService()

--- a/workflows/examples/scripts/deterministic/auto_generate_workflow.py
+++ b/workflows/examples/scripts/deterministic/auto_generate_workflow.py
@@ -10,7 +10,7 @@ import asyncio
 import os
 
 import aiofiles
-from browser_use.llm import ChatOpenAI
+from browser_use.llm import ChatBrowserUse
 
 from workflow_use.healing.service import HealingService
 
@@ -40,7 +40,7 @@ async def auto_generate_workflow():
 
 	# Initialize LLM
 	print('🔧 Initializing LLM...')
-	llm = ChatOpenAI(model='gpt-4o')
+	llm = ChatBrowserUse(model='bu-latest')
 	print('   ✅ LLM initialized')
 	print()
 

--- a/workflows/examples/scripts/deterministic/create_deterministic_workflow.py
+++ b/workflows/examples/scripts/deterministic/create_deterministic_workflow.py
@@ -12,7 +12,7 @@ import asyncio
 import json
 
 import aiofiles
-from browser_use.llm import ChatAnthropic
+from browser_use.llm import ChatBrowserUse
 
 from workflow_use.healing.service import HealingService
 
@@ -30,7 +30,7 @@ async def main():
 	print(f'\nTask: {task.strip()}\n')
 
 	# Initialize LLM (needed for browser agent and optional variable identification)
-	llm = ChatAnthropic(model='claude-3-5-sonnet-20241022', timeout=25)
+	llm = ChatBrowserUse(model='bu-latest')
 
 	# Create HealingService with deterministic conversion enabled
 	print('Initializing HealingService with deterministic conversion...')

--- a/workflows/examples/scripts/deterministic/run_complete_test.py
+++ b/workflows/examples/scripts/deterministic/run_complete_test.py
@@ -15,7 +15,7 @@ import asyncio
 import json
 
 import aiofiles
-from browser_use.llm import ChatAnthropic
+from browser_use.llm import ChatBrowserUse
 
 from workflow_use.healing.service import HealingService
 
@@ -79,7 +79,7 @@ async def main():
 
 	# Setup
 	print('Step 1: Initializing...')
-	llm = ChatAnthropic(model='claude-3-5-sonnet-20241022', timeout=25)
+	llm = ChatBrowserUse(model='bu-latest')
 
 	service = HealingService(
 		llm=llm,

--- a/workflows/examples/scripts/deterministic/test_custom_task.py
+++ b/workflows/examples/scripts/deterministic/test_custom_task.py
@@ -9,7 +9,7 @@ import asyncio
 import json
 
 import aiofiles
-from browser_use.llm import ChatAnthropic
+from browser_use.llm import ChatBrowserUse
 
 from workflow_use.healing.service import HealingService
 
@@ -25,7 +25,7 @@ async def main():
 	print('=' * 80)
 	print(f'Task: {task.strip()}\n')
 
-	llm = ChatAnthropic(model='claude-3-5-sonnet-20241022', timeout=25)
+	llm = ChatBrowserUse(model='bu-latest')
 
 	# Create service with deterministic conversion
 	service = HealingService(

--- a/workflows/examples/scripts/deterministic/test_deterministic_workflow.py
+++ b/workflows/examples/scripts/deterministic/test_deterministic_workflow.py
@@ -15,7 +15,7 @@ import asyncio
 import json
 
 import aiofiles
-from browser_use.llm import ChatAnthropic
+from browser_use.llm import ChatBrowserUse
 
 from workflow_use.healing.service import HealingService
 
@@ -32,7 +32,7 @@ async def test_deterministic_generation():
 	print(f'\nTask: {task}\n')
 
 	# Initialize LLM (still needed for variable identification and browser agent)
-	llm = ChatAnthropic(model='claude-3-5-sonnet-20241022', timeout=25)
+	llm = ChatBrowserUse(model='bu-latest')
 
 	# Test 1: Deterministic conversion (new approach)
 	print('\n' + '=' * 80)

--- a/workflows/examples/scripts/runner.py
+++ b/workflows/examples/scripts/runner.py
@@ -1,10 +1,10 @@
 import asyncio
 
-from browser_use.llm import ChatOpenAI
+from browser_use.llm import ChatBrowserUse
 
 from workflow_use.workflow.service import Workflow
 
-llm = ChatOpenAI(model='gpt-4.1-mini')
+llm = ChatBrowserUse(model='bu-latest')
 
 
 async def main():

--- a/workflows/examples/scripts/variables/create_workflow_with_variables.py
+++ b/workflows/examples/scripts/variables/create_workflow_with_variables.py
@@ -82,9 +82,9 @@ def example_2_automatic_llm():
 	print('\n💻 Code example:')
 	print("""
     from workflow_use.healing.service import HealingService
-    from browser_use.llm import ChatOpenAI
+    from browser_use.llm import ChatBrowserUse
 
-    llm = ChatOpenAI(model='gpt-4o')
+    llm = ChatBrowserUse(model='bu-latest')
     service = HealingService(llm=llm)
 
     # Generate workflow - variables created automatically!

--- a/workflows/examples/scripts/variables/run_workflow_with_variables.py
+++ b/workflows/examples/scripts/variables/run_workflow_with_variables.py
@@ -110,9 +110,9 @@ def example_1_github_stars():
 	print('\n💻 Actual code to run:')
 	print("""
     from workflow_use.workflow.service import Workflow
-    from browser_use.llm import ChatOpenAI
+    from browser_use.llm import ChatBrowserUse
 
-    llm = ChatOpenAI(model='gpt-4o')
+    llm = ChatBrowserUse(model='bu-latest')
     workflow = Workflow.load_from_file(
         'examples/github_stars_parameterized.workflow.json',
         llm=llm
@@ -381,9 +381,9 @@ def main():
 	print('\n💻 To Run a Workflow:')
 	print("""
     from workflow_use.workflow.service import Workflow
-    from browser_use.llm import ChatOpenAI
+    from browser_use.llm import ChatBrowserUse
 
-    llm = ChatOpenAI(model='gpt-4o')
+    llm = ChatBrowserUse(model='bu-latest')
     workflow = Workflow.load_from_file('workflow.json', llm=llm)
 
     # Run with inputs

--- a/workflows/pyproject.toml
+++ b/workflows/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 
 dependencies = [
     "aiofiles>=24.1.0",
-    "browser-use>=0.8.0",
+    "browser-use>=0.9.0",
     "fastapi>=0.115.12",
     "fastmcp>=2.3.4",
     "typer>=0.15.3",

--- a/workflows/tests/test_recorded_workflow.py
+++ b/workflows/tests/test_recorded_workflow.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 
-from browser_use.llm import ChatOpenAI
+from browser_use.llm import ChatBrowserUse
 
 from workflow_use.workflow.service import Workflow
 
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 async def main():
-	llm = ChatOpenAI(model='gpt-4o-mini')
+	llm = ChatBrowserUse(model='bu-latest')
 	workflow = Workflow.load_from_file('tmp/temp_recording_kn1yz829.json', llm)
 
 	logger.info('Starting workflow execution...')

--- a/workflows/uv.lock
+++ b/workflows/uv.lock
@@ -194,7 +194,7 @@ wheels = [
 
 [[package]]
 name = "browser-use"
-version = "0.8.1"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -229,9 +229,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid7" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/d6/8cd999429c441732598a500f8e656db1635aeb47530eb466713bbd7712dd/browser_use-0.8.1.tar.gz", hash = "sha256:72f535b0d1ca89071e4b165879a9cfd10ccb085d5407e31064fa12f9ba328522", size = 349624, upload-time = "2025-10-14T22:02:33.4Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/e4/7a878e36de58d84eef2d1c2cc2dcd67f15efc985d5cb66a0de2c56690b6a/browser_use-0.9.1.tar.gz", hash = "sha256:c1529cfe487e0dc627512eeab0554c4afa771cacf64632ddb484c63985c3bf50", size = 404187, upload-time = "2025-10-24T09:55:47.067Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/e2/3d84dbdc3d73b8adce2d101c030e298e64292000b2bc6c6c6978dea86aa3/browser_use-0.8.1-py3-none-any.whl", hash = "sha256:8d9bf299bbebad62a1bf5592149567bd60e867acd4b979a01e62db37f3f02629", size = 424815, upload-time = "2025-10-14T22:02:31.889Z" },
+    { url = "https://files.pythonhosted.org/packages/34/1a/1b4b8ff7cbc0a002515d5a2bc96ae827b2e481ccbacce147ef443b0ebeb0/browser_use-0.9.1-py3-none-any.whl", hash = "sha256:4700c40a4cf8397f33797ef1b980b13a86f1f1ca4eb66bbe2d58e5d212e7838a", size = 487156, upload-time = "2025-10-24T09:55:45.477Z" },
 ]
 
 [[package]]
@@ -4775,7 +4775,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
-    { name = "browser-use", specifier = ">=0.8.0" },
+    { name = "browser-use", specifier = ">=0.9.0" },
     { name = "faiss-cpu", specifier = "==1.10.0" },
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "fastmcp", specifier = ">=2.3.4" },

--- a/workflows/workflow_use/builder/tests/build_workflow.py
+++ b/workflows/workflow_use/builder/tests/build_workflow.py
@@ -1,12 +1,12 @@
 import asyncio
 from pathlib import Path
 
-from browser_use.llm import ChatOpenAI
+from browser_use.llm import ChatBrowserUse
 
 from workflow_use.builder.service import BuilderService
 
 # Instantiate the LLM and the service directly
-llm_instance = ChatOpenAI(model='gpt-4.1')  # Or your preferred model
+llm_instance = ChatBrowserUse(model='bu-latest')  # Or your preferred model
 builder_service = BuilderService(llm=llm_instance)
 
 

--- a/workflows/workflow_use/healing/_agent/controller.py
+++ b/workflows/workflow_use/healing/_agent/controller.py
@@ -2,18 +2,15 @@ import logging
 import os
 
 from browser_use import ActionResult, Controller
-from browser_use.llm import ChatOpenAI
+from browser_use.llm import ChatBrowserUse
 from browser_use.llm.base import BaseChatModel
 from pydantic import BaseModel, Field, SecretStr
 
 logger = logging.getLogger(__name__)
 
 
-page_extraction_llm = ChatOpenAI(
-	base_url='https://api.groq.com/openai/v1',
-	model='meta-llama/llama-4-scout-17b-16e-instruct',
-	api_key=SecretStr(os.environ['GROQ_API_KEY']),
-	temperature=0.0,
+page_extraction_llm = ChatBrowserUse(
+	model='bu-latest',
 )
 
 

--- a/workflows/workflow_use/healing/tests/test_exploration_agent.py
+++ b/workflows/workflow_use/healing/tests/test_exploration_agent.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 from browser_use import Agent, Browser
-from browser_use.llm import ChatOpenAI
+from browser_use.llm import ChatBrowserUse
 from pydantic import SecretStr
 
 from workflow_use.healing._agent.controller import HealingController
@@ -12,14 +12,14 @@ from workflow_use.healing.tests.constants import TASK_MESSAGE
 logger = logging.getLogger(__name__)
 
 
-llm = ChatOpenAI(
+llm = ChatBrowserUse(
 	base_url='https://api.groq.com/openai/v1',
 	model='meta-llama/llama-4-maverick-17b-128e-instruct',
 	api_key=SecretStr(os.environ['GROQ_API_KEY']),
-	# model='gpt-4.1-mini',
+	# model='bu-latest',
 	temperature=0.0,
 )
-page_extraction_llm = ChatOpenAI(
+page_extraction_llm = ChatBrowserUse(
 	base_url='https://api.groq.com/openai/v1',
 	model='meta-llama/llama-4-scout-17b-16e-instruct',
 	api_key=SecretStr(os.environ['GROQ_API_KEY']),

--- a/workflows/workflow_use/healing/tests/test_generate_workflow.py
+++ b/workflows/workflow_use/healing/tests/test_generate_workflow.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 
 import aiofiles
-from browser_use.llm import ChatOpenAI
+from browser_use.llm import ChatBrowserUse
 from pydantic import SecretStr
 
 from workflow_use.healing.service import HealingService
@@ -20,13 +20,13 @@ async def test_generate_workflow_from_prompt():
 	"""
 
 	# LLM for workflow creation (use high-quality model)
-	workflow_llm = ChatOpenAI(
-		model='gpt-4.1',
+	workflow_llm = ChatBrowserUse(
+		model='bu-latest',
 		temperature=0.0,
 	)
 
 	# LLM for browser agent (can use faster model)
-	agent_llm = ChatOpenAI(
+	agent_llm = ChatBrowserUse(
 		base_url='https://api.groq.com/openai/v1',
 		model='meta-llama/llama-4-maverick-17b-128e-instruct',
 		api_key=SecretStr(os.environ['GROQ_API_KEY']),
@@ -34,7 +34,7 @@ async def test_generate_workflow_from_prompt():
 	)
 
 	# LLM for page extraction (specialized model)
-	extraction_llm = ChatOpenAI(
+	extraction_llm = ChatBrowserUse(
 		base_url='https://api.groq.com/openai/v1',
 		model='meta-llama/llama-4-scout-17b-16e-instruct',
 		api_key=SecretStr(os.environ['GROQ_API_KEY']),

--- a/workflows/workflow_use/healing/tests/test_workflow_creation.py
+++ b/workflows/workflow_use/healing/tests/test_workflow_creation.py
@@ -5,13 +5,13 @@ from pathlib import Path
 import aiofiles
 from browser_use import AgentHistoryList
 from browser_use.agent.views import AgentOutput
-from browser_use.llm import ChatOpenAI
+from browser_use.llm import ChatBrowserUse
 
 from workflow_use.healing._agent.controller import HealingController
 from workflow_use.healing.service import HealingService
 from workflow_use.healing.tests.constants import TASK_MESSAGE
 
-llm = ChatOpenAI(model='gpt-4.1', temperature=0)
+llm = ChatBrowserUse(model='bu-latest')
 
 
 ActionModel = HealingController(extraction_llm=llm).registry.create_action_model()

--- a/workflows/workflow_use/mcp/tests/test_tools.py
+++ b/workflows/workflow_use/mcp/tests/test_tools.py
@@ -1,10 +1,10 @@
-from browser_use.llm import ChatOpenAI
+from browser_use.llm import ChatBrowserUse
 
 from workflow_use.mcp.service import get_mcp_server
 
 # async def main():
 if __name__ == '__main__':
-	llm_instance = ChatOpenAI(model='gpt-4.1', temperature=0)
+	llm_instance = ChatBrowserUse(model='bu-latest')
 
 	print('[FastMCP Server] Starting MCP server...')
 	# This will run the FastMCP server, typically using stdio transport by default.

--- a/workflows/workflow_use/workflow/tests/run_workflow.py
+++ b/workflows/workflow_use/workflow/tests/run_workflow.py
@@ -1,12 +1,12 @@
 import asyncio
 from pathlib import Path
 
-from browser_use.llm import ChatOpenAI
+from browser_use.llm import ChatBrowserUse
 
 from workflow_use.workflow.service import Workflow
 
 # Instantiate the LLM and the service directly
-llm_instance = ChatOpenAI(model='gpt-4.1')  # Or your preferred model
+llm_instance = ChatBrowserUse(model='bu-latest')  # Or your preferred model
 
 
 async def test_run_workflow():

--- a/workflows/workflow_use/workflow/tests/run_workflow_tool.py
+++ b/workflows/workflow_use/workflow/tests/run_workflow_tool.py
@@ -1,13 +1,13 @@
 import asyncio
 from pathlib import Path
 
-from browser_use.llm import ChatOpenAI
+from browser_use.llm import ChatBrowserUse
 
 from workflow_use.workflow.service import Workflow
 
 # Instantiate the LLM and the service directly
-llm_instance = ChatOpenAI(model='gpt-4.1-mini')  # Or your preferred model
-page_extraction_llm = ChatOpenAI(model='gpt-4.1-mini')
+llm_instance = ChatBrowserUse(model='bu-latest')  # Or your preferred model
+page_extraction_llm = ChatBrowserUse(model='bu-latest')
 
 
 async def test_run_workflow():

--- a/workflows/workflow_use/workflow/tests/test_extract.py
+++ b/workflows/workflow_use/workflow/tests/test_extract.py
@@ -1,14 +1,14 @@
 import asyncio
 from pathlib import Path
 
-from browser_use.llm import ChatOpenAI
+from browser_use.llm import ChatBrowserUse
 from pydantic import BaseModel
 
 from workflow_use.workflow.service import Workflow
 
 # Instantiate the LLM and the service directly
-llm_instance = ChatOpenAI(model='gpt-4.1')  # Or your preferred model
-page_extraction_llm = ChatOpenAI(model='gpt-4.1-mini')
+llm_instance = ChatBrowserUse(model='bu-latest')  # Or your preferred model
+page_extraction_llm = ChatBrowserUse(model='bu-latest')
 
 
 class OutputModel(BaseModel):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the default LLM to Browser Use (ChatBrowserUse, bu-latest) and updated env/config to use BROWSER_USE_API_KEY. Addresses Linear 106 by making Browser Use the default model across backend, CLI, MCP server, healing, examples, and tests.

- **Refactors**
  - Replaced ChatOpenAI/ChatAnthropic with ChatBrowserUse(model='bu-latest') for agent and extraction.
  - CLI now prompts for BROWSER_USE_API_KEY; removed OpenAI/Groq-specific init paths.
  - Healing controller uses ChatBrowserUse for page extraction.
  - Upgraded dependency to browser-use >= 0.9.0.

- **Migration**
  - Set BROWSER_USE_API_KEY in your environment before running.
  - To use another provider/model, pass a custom BaseChatModel to services.

<!-- End of auto-generated description by cubic. -->

