### PR TITLE
updated github release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   tag_pre_release:
@@ -54,7 +53,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
       - run: uv run ruff check --no-fix --select PLE # check only for syntax errors
       - run: uv build
-      - run: uv publish --trusted-publishing always
+      - run: uv publish --token ${{ secrets.PYPI_API_TOKEN }}
       - name: Push to stable branch (if stable release)
         if: startsWith(github.ref_name, 'v') && !contains(github.ref_name, 'rc')
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch release workflow to publish to PyPI with an API token instead of trusted publishing. Removes the id-token permission and uses secrets.PYPI_API_TOKEN to improve reliability where OIDC isn’t configured.

- **Migration**
  - Add PYPI_API_TOKEN as a repo/org secret with PyPI publish scope.

<!-- End of auto-generated description by cubic. -->

