### PR TITLE
fixed import path for prompts

### DIFF
--- a/workflows/pyproject.toml
+++ b/workflows/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "workflow-use"
-version = "0.2.3"
+version = "0.2.4"
 authors = [{ name = "Gregor Zunic" }]
 description = "Create, edit, run deterministic workflows"
 readme = "README.md"

--- a/workflows/workflow_use/healing/prompts.py
+++ b/workflows/workflow_use/healing/prompts.py
@@ -1,1 +1,6 @@
-HEALING_AGENT_SYSTEM_PROMPT = open('workflow_use/healing/_agent/agent_prompt.md').read()
+import os
+from pathlib import Path
+
+# Use __file__ to get absolute path relative to this file's location
+_PROMPTS_DIR = Path(__file__).parent / '_agent'
+HEALING_AGENT_SYSTEM_PROMPT = (_PROMPTS_DIR / 'agent_prompt.md').read_text()

--- a/workflows/workflow_use/healing/service.py
+++ b/workflows/workflow_use/healing/service.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+from pathlib import Path
 from typing import Any, Dict, List, Sequence, Union
 
 import aiofiles
@@ -15,6 +16,9 @@ from workflow_use.healing.validator import WorkflowValidator
 from workflow_use.healing.variable_extractor import VariableExtractor
 from workflow_use.healing.views import ParsedAgentStep, SimpleDomElement, SimpleResult
 from workflow_use.schema.views import SelectorWorkflowSteps, WorkflowDefinitionSchema
+
+# Get the absolute path to the prompts directory
+_PROMPTS_DIR = Path(__file__).parent / 'prompts'
 
 
 class HealingService:
@@ -141,7 +145,9 @@ class HealingService:
 	async def create_workflow_definition(
 		self, task: str, history_list: AgentHistoryList, extract_variables: bool = True
 	) -> WorkflowDefinitionSchema:
-		async with aiofiles.open('workflow_use/healing/prompts/workflow_creation_prompt.md', mode='r') as f:
+		# Load prompt using absolute path
+		prompt_file = _PROMPTS_DIR / 'workflow_creation_prompt.md'
+		async with aiofiles.open(prompt_file, mode='r') as f:
 			prompt_content = await f.read()
 
 		prompt_content = prompt_content.format(goal=task, actions=BuilderService._get_available_actions_markdown())

--- a/workflows/workflow_use/healing/tests/test_exploration_agent.py
+++ b/workflows/workflow_use/healing/tests/test_exploration_agent.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+from pathlib import Path
 
 from browser_use import Agent, Browser
 from browser_use.llm import ChatBrowserUse
@@ -26,7 +27,9 @@ page_extraction_llm = ChatBrowserUse(
 	temperature=0.0,
 )
 
-system_prompt = open('workflow_use/healing/_agent/agent_prompt.md').read()
+# Use absolute path for prompt file
+_PROMPT_FILE = Path(__file__).parent.parent / '_agent' / 'agent_prompt.md'
+system_prompt = _PROMPT_FILE.read_text()
 
 
 async def explore_page():

--- a/workflows/workflow_use/healing/validator.py
+++ b/workflows/workflow_use/healing/validator.py
@@ -8,6 +8,7 @@ This module provides tools to:
 """
 
 import json
+from pathlib import Path
 from typing import List, Optional
 
 import aiofiles
@@ -16,6 +17,9 @@ from browser_use.llm.base import BaseChatModel
 from pydantic import BaseModel, Field
 
 from workflow_use.schema.views import WorkflowDefinitionSchema
+
+# Get the absolute path to the prompts directory
+_PROMPTS_DIR = Path(__file__).parent / 'prompts'
 
 
 class WorkflowIssue(BaseModel):
@@ -56,8 +60,9 @@ class WorkflowValidator:
 		Returns:
 		    WorkflowValidationResult with identified issues and optional corrections
 		"""
-		# Load validation prompt
-		async with aiofiles.open('workflow_use/healing/prompts/workflow_validation_prompt.md', mode='r') as f:
+		# Load validation prompt using absolute path
+		prompt_file = _PROMPTS_DIR / 'workflow_validation_prompt.md'
+		async with aiofiles.open(prompt_file, mode='r') as f:
 			prompt_content = await f.read()
 
 		# Prepare workflow JSON for review


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch prompt file loading to absolute paths using Path(__file__) to fix failures when running outside the repo root. Updates healing service, validator, and exploration agent test; bumps package version to 0.2.4.

- **Bug Fixes**
  - Load agent and workflow prompts via absolute paths in prompts.py, service.py, and validator.py.
  - Update test_exploration_agent to use Path for the system prompt.
  - Increment project version to 0.2.4.

<sup>Written for commit 8aff28d7a2964b14a7337c0c6eeaf7849faf482c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

