### PR TITLE
fixed md path issue in package build

### DIFF
--- a/workflows/pyproject.toml
+++ b/workflows/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "workflow-use"
-version = "0.2.4"
+version = "0.2.5"
 authors = [{ name = "Gregor Zunic" }]
 description = "Create, edit, run deterministic workflows"
 readme = "README.md"
@@ -58,7 +58,8 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build]
 include = [
-    "workflow_use/**/*.py"
+    "workflow_use/**/*.py",
+    "workflow_use/**/*.md",
 ]
 
 [tool.hatch.metadata]

--- a/workflows/uv.lock
+++ b/workflows/uv.lock
@@ -4807,7 +4807,7 @@ wheels = [
 
 [[package]]
 name = "workflow-use"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the package build by adding "workflow_use/**/*.md" to Hatch's include list so Markdown docs ship with the distribution. Bumped the package version to publish the fix.

<sup>Written for commit e272e277f450a49650419ea9325eb4239d36124f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

