### PR TITLE
Add Browser Use Box workflow link

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ result = await workflow.run_with_no_ai()  # No LLM calls, uses semantic mapping
 Examples:
 - `examples/cloud_browser_demo.py` - Load recorded workflow and run on cloud
 
+Want to run browser workflows continuously from your own VPS or Telegram? See [Browser Use Box](https://browser-use.com/bux) and the [15-second TikTok demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
+
 ## Launch the GUI
 
 The Workflow UI provides a visual interface for managing, viewing, and executing workflows.


### PR DESCRIPTION
## Summary
- add a Browser Use Box link in the Cloud Browser Support section
- link the 15-second TikTok demo for the always-on workflow use case

## Validation
- README-only change; verified links are present locally

Browser Use Box: https://browser-use.com/bux
TikTok demo: https://www.tiktok.com/@browser_use/video/7639824093721758989

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Browser Use Box and a 15-second TikTok demo links to the README to show how to run always-on browser workflows from a VPS or Telegram. Helps users quickly discover the VPS/Telegram workflow option.

<sup>Written for commit 85ce5a8500f438c8e79462fc5202d4da05a5d46b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

