### PR TITLE
Revert "Add Browser Use Box workflow link"

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,6 @@ result = await workflow.run_with_no_ai()  # No LLM calls, uses semantic mapping
 Examples:
 - `examples/cloud_browser_demo.py` - Load recorded workflow and run on cloud
 
-Want to run browser workflows continuously from your own VPS or Telegram? See [Browser Use Box](https://browser-use.com/bux) and the [15-second TikTok demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
-
 ## Launch the GUI
 
 The Workflow UI provides a visual interface for managing, viewing, and executing workflows.


### PR DESCRIPTION
Reverts browser-use/workflow-use#150

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the earlier addition of the Browser Use Box link by removing the external link and TikTok demo from the README. Keeps the docs focused on core workflows.

<sup>Written for commit afd8231d2847c0d57dad80c22604ee13148b56aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

