### PR TITLE
fix(variable_utils): parse YAML workflow files instead of crashing with JSONDecodeError

### DIFF
--- a/workflows/tests/test_variable_utils_yaml.py
+++ b/workflows/tests/test_variable_utils_yaml.py
@@ -1,0 +1,19 @@
+"""Test that process_workflow_file_with_markers handles YAML workflow files."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from workflow_use.healing.variable_utils import process_workflow_file_with_markers
+
+_FIXTURE = Path(__file__).parent / 'test_go_back.workflow.yaml'
+
+
+def test_process_yaml_workflow_does_not_raise(tmp_path):
+	"""YAML workflow files must be parsed without JSONDecodeError."""
+	output_file = tmp_path / 'output.json'
+	result = process_workflow_file_with_markers(_FIXTURE, output_path=output_file)
+	assert output_file.exists()
+	data = json.loads(output_file.read_text())
+	assert data['name'] == 'Test Go Back'

--- a/workflows/workflow_use/healing/variable_utils.py
+++ b/workflows/workflow_use/healing/variable_utils.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from typing import Optional
 
+import yaml
+
 from workflow_use.healing.variable_extractor import VariableExtractor
 from workflow_use.schema.views import WorkflowDefinitionSchema
 
@@ -57,9 +59,12 @@ def process_workflow_file_with_markers(
 	input_path = Path(input_path)
 	output_path = Path(output_path) if output_path else input_path
 
-	# Load the workflow
+	# Load the workflow — storage service persists as YAML; fall back to JSON
 	with open(input_path, 'r') as f:
-		workflow_data = json.load(f)
+		if input_path.suffix in {'.yaml', '.yml'}:
+			workflow_data = yaml.safe_load(f)
+		else:
+			workflow_data = json.load(f)
 
 	workflow = WorkflowDefinitionSchema(**workflow_data)
 


### PR DESCRIPTION
## What's broken

`process_workflow_file_with_markers()` in `workflows/workflow_use/healing/variable_utils.py` hard-codes `json.load(f)` to parse the workflow file (line 62). The `WorkflowStorageService` always serialises workflows to YAML (`*.workflow.yaml`), so calling this utility on any normal workflow file raises `json.decoder.JSONDecodeError` before any business logic executes.

## Why it happens

The load call never checks the file extension. YAML content is not valid JSON, so `json.load` fails immediately on the first character.

## Fix

Add a two-line branch before the load: if the file suffix is `.yaml` or `.yml`, use `yaml.safe_load`; otherwise fall back to the existing `json.load`. No other code paths are touched.

## Test

Added `tests/test_variable_utils_yaml.py` with one test that calls the function on the existing `test_go_back.workflow.yaml` fixture, asserts no exception is raised, and verifies the output JSON contains the expected workflow name.

Fixes #156

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when reading YAML workflow files by parsing them as YAML. `process_workflow_file_with_markers` now works with workflows saved by the storage service.

- **Bug Fixes**
  - Detect `.yaml`/`.yml` inputs and use `yaml.safe_load`; fall back to `json.load` for others.
  - Added `tests/test_variable_utils_yaml.py` to ensure no exception and the output includes the correct workflow name.

<sup>Written for commit c568200d90504b3d0fe40cbc21c6d9ee6b29f38a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/workflow-use/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

