### PR TITLE
Fix recording pipeline and deterministic replay on browser-use 0.13 / Chrome 137+

### DIFF
--- a/ui/src/components/record-button.tsx
+++ b/ui/src/components/record-button.tsx
@@ -74,8 +74,10 @@ const RecordButton: React.FC<RecordButtonProps> = ({ onRecordingSaved }) => {
       const res = await fetch(`${API_BASE}/api/workflows/recordings/stop`, {
         method: "POST",
       });
-      applyStatus((await res.json()) as RecordingStatus);
-      if ((status.status as string) === "saving") startPolling();
+      const next = (await res.json()) as RecordingStatus;
+      applyStatus(next);
+      // Decide from the response, not the pre-request closure state.
+      if (next.status === "saving") startPolling();
     } catch (e) {
       setStatus({ status: "error", message: String(e) });
     } finally {

--- a/ui/src/components/record-button.tsx
+++ b/ui/src/components/record-button.tsx
@@ -1,0 +1,125 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+const API_BASE = "http://localhost:8000";
+
+type RecordingStatus = {
+  status: "idle" | "recording" | "saving" | "done" | "error" | "no_data";
+  message?: string | null;
+  workflow_file?: string | null;
+};
+
+interface RecordButtonProps {
+  onRecordingSaved: (workflowFile: string) => void;
+}
+
+const RecordButton: React.FC<RecordButtonProps> = ({ onRecordingSaved }) => {
+  const [status, setStatus] = useState<RecordingStatus>({ status: "idle" });
+  const [busy, setBusy] = useState(false);
+  const pollRef = useRef<number | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current !== null) {
+      window.clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const applyStatus = useCallback(
+    (next: RecordingStatus) => {
+      setStatus(next);
+      if (next.status !== "recording" && next.status !== "saving") {
+        stopPolling();
+        if (next.status === "done" && next.workflow_file) {
+          onRecordingSaved(next.workflow_file);
+        }
+      }
+    },
+    [onRecordingSaved, stopPolling]
+  );
+
+  const poll = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/api/workflows/recordings/status`);
+      applyStatus((await res.json()) as RecordingStatus);
+    } catch {
+      /* backend briefly unreachable — keep polling */
+    }
+  }, [applyStatus]);
+
+  const startPolling = useCallback(() => {
+    stopPolling();
+    pollRef.current = window.setInterval(poll, 2000);
+  }, [poll, stopPolling]);
+
+  useEffect(() => stopPolling, [stopPolling]);
+
+  const start = async () => {
+    setBusy(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/workflows/recordings/start`, {
+        method: "POST",
+      });
+      applyStatus((await res.json()) as RecordingStatus);
+      startPolling();
+    } catch (e) {
+      setStatus({ status: "error", message: String(e) });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const stop = async () => {
+    setBusy(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/workflows/recordings/stop`, {
+        method: "POST",
+      });
+      applyStatus((await res.json()) as RecordingStatus);
+      if ((status.status as string) === "saving") startPolling();
+    } catch (e) {
+      setStatus({ status: "error", message: String(e) });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const isRecording = status.status === "recording" || status.status === "saving";
+
+  return (
+    <div className="mb-3">
+      <button
+        onClick={isRecording ? stop : start}
+        disabled={busy}
+        className={`w-full rounded py-2 text-sm font-semibold text-white transition-colors ${
+          isRecording
+            ? "bg-red-600 hover:bg-red-700"
+            : "bg-blue-500 hover:bg-blue-600"
+        } ${busy ? "opacity-60" : ""}`}
+      >
+        {isRecording ? "■ Stop Recording" : "● Record New Workflow"}
+      </button>
+
+      {status.status === "recording" && (
+        <p className="mt-2 text-xs text-[#aaa]">
+          Recording… interact in the opened browser window, then click Stop (or
+          close the browser).
+        </p>
+      )}
+      {status.status === "saving" && (
+        <p className="mt-2 text-xs text-[#aaa]">Saving recording…</p>
+      )}
+      {status.status === "done" && status.workflow_file && (
+        <p className="mt-2 text-xs text-green-400">
+          Saved: {status.workflow_file}
+        </p>
+      )}
+      {(status.status === "error" || status.status === "no_data") && (
+        <p className="mt-2 text-xs text-red-400">
+          {status.message ?? "Recording failed"}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default RecordButton;

--- a/ui/src/components/sidebar.tsx
+++ b/ui/src/components/sidebar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import WorkflowItem from "./workflow-item";
+import RecordButton from "./record-button";
 import { WorkflowMetadata } from "../types/workflow-layout.types";
 
 interface SidebarProps {
@@ -9,6 +10,7 @@ interface SidebarProps {
   workflowMetadata: WorkflowMetadata | null;
   onUpdateMetadata: (metadata: WorkflowMetadata) => Promise<void>;
   allWorkflowsMetadata?: Record<string, WorkflowMetadata>;
+  onRecordingSaved: (workflowFile: string) => void;
 }
 
 export const Sidebar: React.FC<SidebarProps> = ({
@@ -18,6 +20,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   workflowMetadata,
   onUpdateMetadata,
   allWorkflowsMetadata = {},
+  onRecordingSaved,
 }) => (
   <aside className="w-[250px] border-r border-[#542e2e] p-3 bg-[#2a2a2a] text-white flex flex-col overflow-auto">
     {/* logo */}
@@ -30,6 +33,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
     </div>
 
     <h3 className="text-lg text-[#ddd]">Workflows</h3>
+
+    <RecordButton onRecordingSaved={onRecordingSaved} />
 
     <ul className="m-0 p-0">
       {workflows.map((id) => (

--- a/ui/src/components/workflow-layout.tsx
+++ b/ui/src/components/workflow-layout.tsx
@@ -26,6 +26,7 @@ import { NodeConfigMenu } from "./node-config-menu";
 import { PlayButton } from "./play-button";
 import NoWorkflowsMessage from "./no-workflow-message";
 import { $api, fetchClient } from "../lib/api";
+import { useQueryClient } from "@tanstack/react-query";
 
 const WorkflowLayout: React.FC = () => {
   const [selected, setSelected] = useState<string | null>(null);
@@ -41,6 +42,16 @@ const WorkflowLayout: React.FC = () => {
     Record<string, WorkflowMetadata>
   >({});
   const { fitView } = useReactFlow();
+  const queryClient = useQueryClient();
+
+  // After a GUI recording is saved, reload the list and select the new file
+  const handleRecordingSaved = useCallback(
+    (workflowFile: string) => {
+      queryClient.invalidateQueries();
+      setSelected(workflowFile);
+    },
+    [queryClient]
+  );
 
   // ----- Queries using $api -----
   // Fetch all workflows
@@ -218,6 +229,7 @@ const WorkflowLayout: React.FC = () => {
         selected={selected}
         workflowMetadata={workflowMetadata}
         allWorkflowsMetadata={allWorkflowsMetadata}
+        onRecordingSaved={handleRecordingSaved}
         onUpdateMetadata={async (metadata: WorkflowMetadata) => {
           if (selected) {
             await updateWorkflowMetadata(selected, metadata);

--- a/ui/src/components/workflow-layout.tsx
+++ b/ui/src/components/workflow-layout.tsx
@@ -25,7 +25,7 @@ import Sidebar from "./sidebar";
 import { NodeConfigMenu } from "./node-config-menu";
 import { PlayButton } from "./play-button";
 import NoWorkflowsMessage from "./no-workflow-message";
-import { $api } from "../lib/api";
+import { $api, fetchClient } from "../lib/api";
 
 const WorkflowLayout: React.FC = () => {
   const [selected, setSelected] = useState<string | null>(null);
@@ -36,6 +36,9 @@ const WorkflowLayout: React.FC = () => {
     useState<WorkflowMetadata | null>(null);
   const [savedNodePositions, setSavedNodePositions] = useState<
     Record<string, Record<string, { x: number; y: number }>>
+  >({});
+  const [allWorkflowsMetadata, setAllWorkflowsMetadata] = useState<
+    Record<string, WorkflowMetadata>
   >({});
   const { fitView } = useReactFlow();
 
@@ -159,6 +162,37 @@ const WorkflowLayout: React.FC = () => {
     }
   }, [workflows, selected]);
 
+  // Fetch metadata for every workflow so sidebar items show their real
+  // names instead of a permanent "Loading workflow…" placeholder
+  useEffect(() => {
+    if (!workflows.length) return;
+    let cancelled = false;
+    (async () => {
+      const entries = await Promise.all(
+        workflows.map(async (name) => {
+          try {
+            const { data } = await fetchClient.GET("/api/workflows/{name}", {
+              params: { path: { name } },
+            });
+            if (!data) return null;
+            const parsed = typeof data === "string" ? JSON.parse(data) : data;
+            return [name, parsed as WorkflowMetadata] as const;
+          } catch {
+            return null;
+          }
+        })
+      );
+      if (!cancelled) {
+        setAllWorkflowsMetadata(
+          Object.fromEntries(entries.filter((e): e is NonNullable<typeof e> => e !== null))
+        );
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [workflows]);
+
   const isLoading = isLoadingWorkflows || isLoadingSelectedWorkflow;
 
   if (isLoading) {
@@ -183,6 +217,7 @@ const WorkflowLayout: React.FC = () => {
         onSelect={setSelected}
         selected={selected}
         workflowMetadata={workflowMetadata}
+        allWorkflowsMetadata={allWorkflowsMetadata}
         onUpdateMetadata={async (metadata: WorkflowMetadata) => {
           if (selected) {
             await updateWorkflowMetadata(selected, metadata);

--- a/ui/src/components/workflow-layout.tsx
+++ b/ui/src/components/workflow-layout.tsx
@@ -25,7 +25,7 @@ import Sidebar from "./sidebar";
 import { NodeConfigMenu } from "./node-config-menu";
 import { PlayButton } from "./play-button";
 import NoWorkflowsMessage from "./no-workflow-message";
-import { $api, fetchClient } from "../lib/api";
+import { $api } from "../lib/api";
 import { useQueryClient } from "@tanstack/react-query";
 
 const WorkflowLayout: React.FC = () => {
@@ -89,6 +89,12 @@ const WorkflowLayout: React.FC = () => {
       await updateMetadataMutation.mutateAsync({
         body: { name, metadata: metadata as unknown as Record<string, never> },
       });
+      // Keep the sidebar cache in sync, or the row's label reverts to the
+      // pre-save name as soon as another workflow is selected.
+      setAllWorkflowsMetadata((prev) => ({
+        ...prev,
+        [name]: { ...prev[name], ...metadata },
+      }));
     },
     [updateMetadataMutation]
   );
@@ -173,30 +179,24 @@ const WorkflowLayout: React.FC = () => {
     }
   }, [workflows, selected]);
 
-  // Fetch metadata for every workflow so sidebar items show their real
-  // names instead of a permanent "Loading workflow…" placeholder
+  // Fetch lightweight metadata for every workflow in ONE request so sidebar
+  // items show their real names instead of a "Loading workflow…" placeholder
   useEffect(() => {
     if (!workflows.length) return;
     let cancelled = false;
     (async () => {
-      const entries = await Promise.all(
-        workflows.map(async (name) => {
-          try {
-            const { data } = await fetchClient.GET("/api/workflows/{name}", {
-              params: { path: { name } },
-            });
-            if (!data) return null;
-            const parsed = typeof data === "string" ? JSON.parse(data) : data;
-            return [name, parsed as WorkflowMetadata] as const;
-          } catch {
-            return null;
-          }
-        })
-      );
-      if (!cancelled) {
-        setAllWorkflowsMetadata(
-          Object.fromEntries(entries.filter((e): e is NonNullable<typeof e> => e !== null))
-        );
+      try {
+        const res = await fetch("http://localhost:8000/api/workflows/metadata");
+        const data = (await res.json()) as {
+          workflows: Array<{ file: string } & WorkflowMetadata>;
+        };
+        if (!cancelled) {
+          setAllWorkflowsMetadata(
+            Object.fromEntries(data.workflows.map((w) => [w.file, w]))
+          );
+        }
+      } catch {
+        /* list still renders with filename placeholders */
       }
     })();
     return () => {

--- a/workflows/backend/routers.py
+++ b/workflows/backend/routers.py
@@ -7,6 +7,7 @@ from .service import WorkflowService
 from .views import (
 	RecordingStatusResponse,
 	WorkflowCancelResponse,
+	WorkflowMetadataListResponse,
 	WorkflowExecuteRequest,
 	WorkflowExecuteResponse,
 	WorkflowListResponse,
@@ -36,6 +37,13 @@ async def list_workflows():
 	service = get_service()
 	workflows = service.list_workflows()
 	return WorkflowListResponse(workflows=workflows)
+
+
+# NOTE: must be registered before GET /{name}, which would otherwise capture 'metadata'
+@router.get('/metadata', response_model=WorkflowMetadataListResponse)
+async def list_workflow_metadata():
+	service = get_service()
+	return WorkflowMetadataListResponse(workflows=service.list_workflow_metadata())
 
 
 @router.get('/{name}', response_model=str)

--- a/workflows/backend/routers.py
+++ b/workflows/backend/routers.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, HTTPException
 
 from .service import WorkflowService
 from .views import (
+	RecordingStatusResponse,
 	WorkflowCancelResponse,
 	WorkflowExecuteRequest,
 	WorkflowExecuteResponse,
@@ -18,9 +19,16 @@ from .views import (
 
 router = APIRouter(prefix='/api/workflows')
 
+# Single shared service: per-request instances would lose in-memory task
+# and recording state, breaking /tasks/{id}/status and recording control.
+_service: WorkflowService | None = None
+
 
 def get_service() -> WorkflowService:
-	return WorkflowService()
+	global _service
+	if _service is None:
+		_service = WorkflowService()
+	return _service
 
 
 @router.get('', response_model=WorkflowListResponse)
@@ -117,3 +125,21 @@ async def cancel_workflow(task_id: str):
 	if not result.success and result.message == 'Task not found':
 		raise HTTPException(status_code=404, detail=f'Task {task_id} not found')
 	return result
+
+
+@router.post('/recordings/start', response_model=RecordingStatusResponse)
+async def start_recording():
+	service = get_service()
+	return await service.start_recording()
+
+
+@router.post('/recordings/stop', response_model=RecordingStatusResponse)
+async def stop_recording():
+	service = get_service()
+	return await service.stop_recording()
+
+
+@router.get('/recordings/status', response_model=RecordingStatusResponse)
+async def recording_status():
+	service = get_service()
+	return service.recording_status()

--- a/workflows/backend/service.py
+++ b/workflows/backend/service.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional, Tuple
 
 import aiofiles
 import yaml
-from browser_use.browser.browser import Browser
+from browser_use import Browser
 from browser_use.llm import ChatBrowserUse
 
 from workflow_use.controller.service import WorkflowController
@@ -41,8 +41,11 @@ class WorkflowService:
 		self.log_dir: Path = self.tmp_dir / 'logs'
 		self.log_dir.mkdir(exist_ok=True, parents=True)
 
-		# LLM / workflow executor
-		self.llm_instance = ChatBrowserUse(model='bu-latest')
+		# LLM / workflow executor (optional — deterministic runs work without it)
+		try:
+			self.llm_instance = ChatBrowserUse(model='bu-latest')
+		except ValueError:
+			self.llm_instance = None
 
 		self.browser_instance = Browser()
 		self.controller_instance = WorkflowController()

--- a/workflows/backend/service.py
+++ b/workflows/backend/service.py
@@ -10,9 +10,13 @@ from browser_use import Browser
 from browser_use.llm import ChatBrowserUse
 
 from workflow_use.controller.service import WorkflowController
+from workflow_use.recorder.semantic_converter import convert_recorded_workflow_to_semantic
+from workflow_use.recorder.service import RecordingService
+from workflow_use.recorder.views import HttpRecordingStoppedEvent, RecordingStatusPayload
 from workflow_use.workflow.service import Workflow
 
 from .views import (
+	RecordingStatusResponse,
 	TaskInfo,
 	WorkflowCancelResponse,
 	WorkflowExecuteRequest,
@@ -54,6 +58,89 @@ class WorkflowService:
 		self.active_tasks: Dict[str, TaskInfo] = {}
 		self.workflow_tasks: Dict[str, asyncio.Task] = {}
 		self.cancel_events: Dict[str, asyncio.Event] = {}
+
+		# Recording session state (one at a time)
+		self.recording_service: Optional[RecordingService] = None
+		self.recording_task: Optional[asyncio.Task] = None
+		self.recording_result: Optional[RecordingStatusResponse] = None
+
+	# ---------- Recording control ----------
+
+	def _recording_active(self) -> bool:
+		return self.recording_task is not None and not self.recording_task.done()
+
+	async def start_recording(self) -> RecordingStatusResponse:
+		if self._recording_active():
+			return RecordingStatusResponse(status='recording', message='A recording session is already running')
+
+		self.recording_service = RecordingService()
+		self.recording_result = None
+		self.recording_task = asyncio.create_task(self._run_recording_session())
+		return RecordingStatusResponse(
+			status='recording',
+			message='Recording started — interact in the opened browser, then stop the recording',
+		)
+
+	async def _run_recording_session(self) -> None:
+		try:
+			captured = await self.recording_service.capture_workflow()
+			if captured is None:
+				self.recording_result = RecordingStatusResponse(
+					status='no_data', message='Recording ended without capturing any steps'
+				)
+				return
+
+			recording_data = captured.model_dump(mode='json')
+			semantic = convert_recorded_workflow_to_semantic(recording_data)
+
+			filename = f'recorded-{time.strftime("%Y%m%d-%H%M%S")}.workflow.yaml'
+			output_path = self.tmp_dir / filename
+			output_path.write_text(json.dumps(semantic, indent=2))
+			self.recording_result = RecordingStatusResponse(
+				status='done', message='Recording saved', workflow_file=filename
+			)
+		except asyncio.CancelledError:
+			self.recording_result = RecordingStatusResponse(status='no_data', message='Recording cancelled')
+			raise
+		except Exception as exc:  # surface the failure to the UI instead of dying silently
+			self.recording_result = RecordingStatusResponse(status='error', message=str(exc))
+
+	async def stop_recording(self) -> RecordingStatusResponse:
+		if not self._recording_active():
+			return self.recording_result or RecordingStatusResponse(status='idle')
+
+		# No steps captured: the recorder's finalizer would wait forever, so cancel outright.
+		if self.recording_service and self.recording_service.last_workflow_update_event is None:
+			self.recording_task.cancel()
+			try:
+				await self.recording_task
+			except (asyncio.CancelledError, Exception):
+				pass
+			if self.recording_service.browser:
+				try:
+					await self.recording_service.browser.stop()
+				except Exception:
+					pass
+			return self.recording_result or RecordingStatusResponse(
+				status='no_data', message='Recording stopped without capturing any steps'
+			)
+
+		await self.recording_service.event_queue.put(
+			HttpRecordingStoppedEvent(
+				timestamp=int(time.time() * 1000),
+				payload=RecordingStatusPayload(message='Stopped from GUI'),
+			)
+		)
+		try:
+			await asyncio.wait_for(asyncio.shield(self.recording_task), timeout=30)
+		except asyncio.TimeoutError:
+			return RecordingStatusResponse(status='saving', message='Recording is being finalized')
+		return self.recording_result or RecordingStatusResponse(status='error', message='Recording ended unexpectedly')
+
+	def recording_status(self) -> RecordingStatusResponse:
+		if self._recording_active():
+			return RecordingStatusResponse(status='recording')
+		return self.recording_result or RecordingStatusResponse(status='idle')
 
 	async def _log_file_position(self) -> int:
 		log_file = self.log_dir / 'backend.log'

--- a/workflows/backend/service.py
+++ b/workflows/backend/service.py
@@ -51,10 +51,11 @@ class WorkflowService:
 		except ValueError:
 			self.llm_instance = None
 
-		self.browser_instance = Browser()
-		self.controller_instance = WorkflowController()
+		# Browser/controller are created per execution in run_workflow_in_background:
+		# a shared instance would let concurrent tasks close each other's browser.
 
-		# In‑memory task tracking
+		# In‑memory task tracking (completed entries pruned beyond MAX_FINISHED_TASKS)
+		self.MAX_FINISHED_TASKS = 100
 		self.active_tasks: Dict[str, TaskInfo] = {}
 		self.workflow_tasks: Dict[str, asyncio.Task] = {}
 		self.cancel_events: Dict[str, asyncio.Event] = {}
@@ -63,6 +64,13 @@ class WorkflowService:
 		self.recording_service: Optional[RecordingService] = None
 		self.recording_task: Optional[asyncio.Task] = None
 		self.recording_result: Optional[RecordingStatusResponse] = None
+
+	def _prune_finished_tasks(self) -> None:
+		"""Cap remembered finished tasks so long-lived processes don't grow unboundedly."""
+		finished = [tid for tid, info in self.active_tasks.items() if info.status not in ('running', 'pending')]
+		excess = len(finished) - self.MAX_FINISHED_TASKS
+		for tid in finished[:max(0, excess)]:  # dict preserves insertion order → oldest first
+			self.active_tasks.pop(tid, None)
 
 	# ---------- Recording control ----------
 
@@ -116,9 +124,12 @@ class WorkflowService:
 				await self.recording_task
 			except (asyncio.CancelledError, Exception):
 				pass
-			if self.recording_service.browser:
+			# RecordingService.browser is only annotated, not assigned, until the
+			# browser launches — a stop right after start must not AttributeError.
+			browser = getattr(self.recording_service, 'browser', None)
+			if browser:
 				try:
-					await self.recording_service.browser.stop()
+					await browser.stop()
 				except Exception:
 					pass
 			return self.recording_result or RecordingStatusResponse(
@@ -185,6 +196,21 @@ class WorkflowService:
 			and not f.name.startswith('temp_recording')
 			and (f.name.endswith('.workflow.json') or f.name.endswith('.workflow.yaml') or f.name.endswith('.workflow.yml'))
 		]
+
+	def list_workflow_metadata(self) -> list[dict]:
+		"""Lightweight metadata for every workflow — for list views, without shipping full step bodies."""
+		entries = []
+		for name in self.list_workflows():
+			entry: dict = {'file': name}
+			try:
+				content = yaml.safe_load((self.tmp_dir / name).read_text())
+				if isinstance(content, dict):
+					for key in ('name', 'description', 'version', 'input_schema'):
+						entry[key] = content.get(key)
+			except Exception:
+				pass  # unreadable file still gets listed by filename
+			entries.append(entry)
+		return entries
 
 	def get_workflow(self, name: str) -> str:
 		"""Get workflow content, converting YAML to JSON for frontend compatibility."""
@@ -261,6 +287,7 @@ class WorkflowService:
 		inputs = request.inputs
 		log_file = self.log_dir / 'backend.log'
 		try:
+			self._prune_finished_tasks()
 			self.active_tasks[task_id] = TaskInfo(status='running', workflow=workflow_name)
 			ts = time.strftime('%Y-%m-%d %H:%M:%S')
 			await self._write_log(log_file, f"[{ts}] Starting workflow '{workflow_name}'\n")
@@ -273,11 +300,13 @@ class WorkflowService:
 
 			workflow_path = self.tmp_dir / workflow_name
 			try:
-				self.workflow_obj = Workflow.load_from_file(
-					str(workflow_path), llm=self.llm_instance, browser=self.browser_instance, controller=self.controller_instance
+				workflow_obj = Workflow.load_from_file(
+					str(workflow_path), llm=self.llm_instance, browser=Browser(), controller=WorkflowController()
 				)
 			except Exception as e:
-				print(f'Error loading workflow: {e}')
+				await self._write_log(log_file, f'[{ts}] Error loading workflow: {e}\n')
+				self.active_tasks[task_id].status = 'failed'
+				self.active_tasks[task_id].error = str(e)
 				return
 
 			await self._write_log(log_file, f'[{ts}] Executing workflow...\n')
@@ -287,7 +316,7 @@ class WorkflowService:
 				self.active_tasks[task_id].status = 'cancelled'
 				return
 
-			result = await self.workflow_obj.run(inputs, close_browser_at_end=True, cancel_event=cancel_event)
+			result = await workflow_obj.run(inputs, close_browser_at_end=True, cancel_event=cancel_event)
 
 			if cancel_event.is_set():
 				await self._write_log(log_file, f'[{ts}] Workflow execution was cancelled\n')

--- a/workflows/backend/views.py
+++ b/workflows/backend/views.py
@@ -28,6 +28,18 @@ class WorkflowExecuteRequest(BaseModel):
 	inputs: Dict[str, Any]
 
 
+class WorkflowMetadataEntry(BaseModel):
+	file: str
+	name: Optional[str] = None
+	description: Optional[str] = None
+	version: Optional[str] = None
+	input_schema: Optional[list] = None
+
+
+class WorkflowMetadataListResponse(BaseModel):
+	workflows: list[WorkflowMetadataEntry]
+
+
 class RecordingStatusResponse(BaseModel):
 	status: str  # 'idle' | 'recording' | 'saving' | 'done' | 'error' | 'no_data'
 	message: Optional[str] = None

--- a/workflows/backend/views.py
+++ b/workflows/backend/views.py
@@ -28,6 +28,12 @@ class WorkflowExecuteRequest(BaseModel):
 	inputs: Dict[str, Any]
 
 
+class RecordingStatusResponse(BaseModel):
+	status: str  # 'idle' | 'recording' | 'saving' | 'done' | 'error' | 'no_data'
+	message: Optional[str] = None
+	workflow_file: Optional[str] = None
+
+
 # Response Models
 class WorkflowResponse(BaseModel):
 	success: bool

--- a/workflows/cli.py
+++ b/workflows/cli.py
@@ -32,17 +32,16 @@ app = typer.Typer(
 )
 
 # Default LLM instance to None
-llm_instance: BaseChatModel
+llm_instance: BaseChatModel | None = None
+page_extraction_llm: BaseChatModel | None = None
 try:
 	llm_instance = ChatBrowserUse(model='bu-latest')
 	page_extraction_llm = ChatBrowserUse(model='bu-latest')
 except Exception as e:
-	typer.secho(f'Error initializing LLM: {e}. Would you like to set your BROWSER_USE_API_KEY?', fg=typer.colors.RED)
-	set_browser_use_api_key = input('Set BROWSER_USE_API_KEY? (y/n): ')
-	if set_browser_use_api_key.lower() == 'y':
-		os.environ['BROWSER_USE_API_KEY'] = input('Enter your BROWSER_USE_API_KEY: ')
-		llm_instance = ChatBrowserUse(model='bu-latest')
-		page_extraction_llm = ChatBrowserUse(model='bu-latest')
+	typer.secho(
+		f'LLM not available ({e}). Continuing without LLM — no-AI commands still work.',
+		fg=typer.colors.YELLOW,
+	)
 
 builder_service = BuilderService(llm=llm_instance) if llm_instance else None
 # recorder_service = RecorderService() # Placeholder

--- a/workflows/cli.py
+++ b/workflows/cli.py
@@ -1193,6 +1193,13 @@ def run_workflow_command(
 	"""
 	Loads and executes a workflow, prompting the user for required inputs.
 	"""
+	if not llm_instance:
+		typer.secho(
+			'LLM is required for run-workflow (agent steps / fallbacks). Set BROWSER_USE_API_KEY, '
+			'or use run-workflow-no-ai for fully deterministic execution.',
+			fg=typer.colors.RED,
+		)
+		raise typer.Exit(code=1)
 
 	async def _run_workflow():
 		typer.echo(

--- a/workflows/workflow_use/recorder/service.py
+++ b/workflows/workflow_use/recorder/service.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import pathlib
 from typing import Optional
 
@@ -20,6 +21,45 @@ from workflow_use.recorder.views import (
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 EXT_DIR = SCRIPT_DIR.parent.parent.parent / 'extension' / '.output' / 'chrome-mv3'
 USER_DATA_DIR = SCRIPT_DIR / 'user_data_dir'
+
+
+def _find_extension_capable_browser() -> str | None:
+	"""Find a Chromium binary that still honors --load-extension.
+
+	Branded Google Chrome 137+ silently ignores --load-extension, so the
+	recorder extension never loads there and no events reach the recording
+	server. Prefer an explicit override, then Playwright's bundled
+	Chromium/Chrome for Testing, then fall back to browser-use's default.
+	"""
+	override = os.environ.get('WORKFLOW_USE_RECORDER_BROWSER')
+	if override:
+		return override
+
+	playwright_caches = [
+		pathlib.Path.home() / 'Library/Caches/ms-playwright',  # macOS
+		pathlib.Path.home() / '.cache/ms-playwright',  # Linux
+		pathlib.Path(os.environ.get('LOCALAPPDATA', '')) / 'ms-playwright',  # Windows
+	]
+	binary_globs = [
+		'chromium-*/chrome-mac*/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing',
+		'chromium-*/chrome-mac*/Chromium.app/Contents/MacOS/Chromium',
+		'chromium-*/chrome-linux/chrome',
+		'chromium-*/chrome-win/chrome.exe',
+	]
+	for cache in playwright_caches:
+		if not cache.is_dir():
+			continue
+		for pattern in binary_globs:
+			matches = sorted(cache.glob(pattern), reverse=True)  # newest revision first
+			if matches:
+				return str(matches[0])
+
+	print(
+		'[Service] WARNING: No Playwright Chromium found. If recording captures no '
+		'events, branded Google Chrome may be ignoring --load-extension (137+); '
+		'set WORKFLOW_USE_RECORDER_BROWSER to a Chromium/Chrome for Testing binary.'
+	)
+	return None
 
 
 class RecordingService:
@@ -117,6 +157,10 @@ class RecordingService:
 			profile = BrowserProfile(
 				headless=False,
 				user_data_dir=str(USER_DATA_DIR.resolve()),
+				executable_path=_find_extension_capable_browser(),
+				# browser-use's default extensions add a second --load-extension flag
+				# which overrides ours — the recorder extension must win.
+				enable_default_extensions=False,
 				args=[
 					f'--disable-extensions-except={str(EXT_DIR.resolve())}',
 					f'--load-extension={str(EXT_DIR.resolve())}',

--- a/workflows/workflow_use/recorder/service.py
+++ b/workflows/workflow_use/recorder/service.py
@@ -46,11 +46,19 @@ def _find_extension_capable_browser() -> str | None:
 		'chromium-*/chrome-linux/chrome',
 		'chromium-*/chrome-win/chrome.exe',
 	]
+	def _revision(path: pathlib.Path) -> int:
+		# .../ms-playwright/chromium-1234/... — lexicographic sort would rank
+		# chromium-999 above chromium-1017, so compare the revision numerically.
+		for part in path.parts:
+			if part.startswith('chromium-') and part.removeprefix('chromium-').isdigit():
+				return int(part.removeprefix('chromium-'))
+		return -1
+
 	for cache in playwright_caches:
 		if not cache.is_dir():
 			continue
 		for pattern in binary_globs:
-			matches = sorted(cache.glob(pattern), reverse=True)  # newest revision first
+			matches = sorted(cache.glob(pattern), key=_revision, reverse=True)  # newest revision first
 			if matches:
 				return str(matches[0])
 

--- a/workflows/workflow_use/schema/views.py
+++ b/workflows/workflow_use/schema/views.py
@@ -239,22 +239,8 @@ class WorkflowDefinitionSchema(BaseModel):
 
 	@validator('steps')
 	def validate_ends_with_extract(cls, steps: List[WorkflowStep]) -> List[WorkflowStep]:
-		"""Validate that the workflow ends with an extract step."""
-		if not steps:
-			raise ValueError('Workflow must have at least one step')
-
-		last_step = steps[-1]
-		# Check if last step is an extract step
-		# We need to check the 'type' attribute from the step dict/model
-		step_type = getattr(last_step, 'type', None)
-
-		if step_type not in ['extract', 'extract_page_content']:
-			raise ValueError(
-				f'Workflow must end with an extract step (extract or extract_page_content). '
-				f'Current last step type: {step_type}. '
-				f'AI processing is always needed at the end of a workflow.'
-			)
-
+		"""Recordings arrive step-by-step, so an extract-terminated workflow
+		cannot be enforced here — it would reject every incremental update."""
 		return steps
 
 	# Add loader from json file

--- a/workflows/workflow_use/workflow/semantic_executor.py
+++ b/workflows/workflow_use/workflow/semantic_executor.py
@@ -159,43 +159,10 @@ class SemanticWorkflowExecutor:
 			await element.focus()
 			await asyncio.sleep(0.05)
 
-			# Get the page to send key events
+			# Page.press handles named keys, combos, and CDP session setup —
+			# hand-rolled dispatchKeyEvent hit 'method not found' on a stale session.
 			page = await self.browser.get_current_page()
-
-			# Send key event through CDP
-			key_map = {
-				'Enter': {'key': 'Enter', 'code': 'Enter', 'keyCode': 13},
-				'Tab': {'key': 'Tab', 'code': 'Tab', 'keyCode': 9},
-				'Escape': {'key': 'Escape', 'code': 'Escape', 'keyCode': 27},
-				'ArrowDown': {'key': 'ArrowDown', 'code': 'ArrowDown', 'keyCode': 40},
-				'ArrowUp': {'key': 'ArrowUp', 'code': 'ArrowUp', 'keyCode': 38},
-			}
-
-			key_info = key_map.get(key, {'key': key, 'code': f'Key{key.upper()}', 'keyCode': ord(key.upper())})
-
-			# Send keydown
-			await page._client.send.Input.dispatchKeyEvent(
-				params={
-					'type': 'keyDown',
-					'key': key_info['key'],
-					'code': key_info['code'],
-					'windowsVirtualKeyCode': key_info['keyCode'],
-				},
-				session_id=page._session_id,
-			)
-
-			await asyncio.sleep(0.05)
-
-			# Send keyup
-			await page._client.send.Input.dispatchKeyEvent(
-				params={
-					'type': 'keyUp',
-					'key': key_info['key'],
-					'code': key_info['code'],
-					'windowsVirtualKeyCode': key_info['keyCode'],
-				},
-				session_id=page._session_id,
-			)
+			await page.press(key)
 		except Exception as e:
 			raise Exception(f'Failed to press key {key}: {e}')
 
@@ -209,8 +176,15 @@ class SemanticWorkflowExecutor:
 
 	async def _refresh_semantic_mapping(self) -> None:
 		"""Refresh the semantic mapping for the current page."""
-		page = await self.browser.get_current_page()
-		self.current_mapping = await self.semantic_extractor.extract_semantic_mapping(page)
+		# An empty mapping usually means the page is mid-navigation — retry
+		# briefly instead of failing the step on a half-loaded document.
+		for attempt in range(4):
+			page = await self.browser.get_current_page()
+			self.current_mapping = await self.semantic_extractor.extract_semantic_mapping(page)
+			if self.current_mapping:
+				break
+			logger.info(f'Semantic mapping empty (attempt {attempt + 1}/4), waiting for page to settle...')
+			await asyncio.sleep(2)
 		logger.info(f'Refreshed semantic mapping with {len(self.current_mapping)} elements')
 
 		# Print detailed mapping for debugging
@@ -1792,10 +1766,15 @@ class SemanticWorkflowExecutor:
 			logger.info(msg)
 			return ActionResult(extracted_content=msg, include_in_memory=True)
 
+		pre_press_url = await page.get_url()
+
 		async def keypress_verifier():
-			# For key presses, just verify the element is still accessible
-			# (More specific verification could be added based on the key and context)
+			# Keys like Enter often navigate — the element disappearing is then
+			# success, not failure. Treat a URL change as the key taking effect.
 			try:
+				current_page = await self.browser.get_current_page()
+				if await current_page.get_url() != pre_press_url:
+					return True
 				elements = await self._get_elements_by_selector(selector_to_use)
 				if not elements:
 					return False

--- a/workflows/workflow_use/workflow/service.py
+++ b/workflows/workflow_use/workflow/service.py
@@ -144,14 +144,14 @@ class Workflow:
 
 		# Filter out workflow metadata fields that shouldn't be passed to browser-use ActionModel
 		# Note: 'type' is NOT filtered here because some actions (like navigation) need it in their params
+		# cssSelector/xpath must pass through: click/input/key_press/select_change
+		# action models require cssSelector (extras are ignored via extra='ignore').
 		workflow_metadata_fields = {
 			'description',
 			'output',
 			'agent_reasoning',
 			'page_context_url',
 			'page_context_title',
-			'cssSelector',
-			'xpath',
 			'elementTag',
 			'elementHash',  # These are workflow-specific selector fields
 			'selectorStrategies',  # Multi-strategy selectors


### PR DESCRIPTION
Fixes #165

On a fresh clone with the pinned browser-use 0.13.4, recording captures zero events and deterministic replay fails on several step types. This PR restores the full record → build → replay (no-AI) pipeline; each commit is self-contained:

## 1. `fix(recorder)` — recorder extension never loads
- browser-use's default extensions append a second `--load-extension` flag which overrides ours (Chrome honors the last one). Disable default extensions for the recording profile.
- Branded Google Chrome 137+ removed `--load-extension` support altogether. Prefer a Playwright-bundled Chromium / Chrome for Testing binary when present (macOS/Linux/Windows cache paths), overridable via `WORKFLOW_USE_RECORDER_BROWSER`; falls back to browser-use's default with a warning.

## 2. `fix(schema)` — validator 422s every incremental recording update
`validate_ends_with_extract` rejected essentially every `WORKFLOW_UPDATE` streamed by the extension mid-recording, so the recording server never stored any data and `create-workflow` hung after the browser closed. The validator is relaxed; no-AI workflows are also valid without a trailing extract step.

## 3. `fix(workflow)` — deterministic replay on browser-use 0.13
- Stop stripping `cssSelector`/`xpath` from step params: the click/input/key_press/select_change action models **require** `cssSelector` (extras are ignored via `extra='ignore'`), so every selector-based deterministic action failed validation.
- Named-key crash: `dict.get`'s default is evaluated eagerly, so `ord('ENTER')` raised even though `'Enter'` is in the key map.
- Replace the hand-rolled `Input.dispatchKeyEvent` (stale CDP session → `-32601 method not found`) with `page.press()`.
- Key-press verification treated navigation as failure (element gone → retry pressing Enter repeatedly). A URL change now counts as success.
- Retry semantic-mapping extraction briefly when it comes back empty (page mid-navigation) instead of failing the step.

## 4. `fix(cli,backend)` — no-AI paths shouldn't require `BROWSER_USE_API_KEY`
- `cli.py`: `NameError: llm_instance` when LLM init failed; now degrades gracefully.
- backend: `from browser_use.browser.browser import Browser` no longer exists in 0.13; and the eager `ChatBrowserUse` instantiation made every endpoint 500 without an API key. LLM is now optional.

## Verified
- Recording: extension service worker present on the CDP debug port; step events received by the server; `create-workflow-no-ai` produced a valid semantic workflow from a real user recording.
- Replay: `run` executes navigation/input/key_press/click/scroll steps of the recorded workflow deterministically (no API key), including Enter-triggered navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the full record → build → deterministic replay pipeline on `browser-use` 0.13, adds a GUI “Record New Workflow” button backed by new recording APIs, and hardens task/recording state so status/cancel work across requests and concurrent runs. No‑AI workflows now run without `BROWSER_USE_API_KEY`.

- **New Features**
  - GUI recording: sidebar button starts/stops recording, polls `/recordings/status`, and selects the saved file when done.
  - Backend recording: `/recordings/start|stop|status` run `RecordingService`, convert to semantic, and save into `./tmp`; zero‑step stops cancel cleanly.

- **Bug Fixes**
  - Recorder: disable default extensions so our `--load-extension` wins; prefer Playwright-bundled Chromium/Chrome for Testing (newest revision) on Chrome 137+; override via `WORKFLOW_USE_RECORDER_BROWSER`.
  - Backend: share one `WorkflowService` to preserve in‑memory task/recording state; create `Browser`/`WorkflowController` per execution; prune finished tasks; record load errors in task status.
  - Schema: relax “must end with extract” so incremental recording updates are accepted.
  - Workflow: keep `cssSelector`/`xpath`; use `page.press()` for keys; treat URL change as success; retry semantic mapping during navigation.
  - CLI/Backend: optional LLM; `run-workflow` guards on missing LLM; update imports for `browser-use` 0.13.
  - UI: use `GET /api/workflows/metadata` so the sidebar shows real names; keep metadata cache in sync after saves; record button stop/polling logic is more robust.

<sup>Written for commit 8defbb418308f279644e475ce2afab354a10d319. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/workflow-use/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

