### PR TITLE
fix(healing): escape stray {variable} placeholders that crash every LLM workflow generation

### DIFF
--- a/workflows/workflow_use/healing/prompts/workflow_creation_prompt.md
+++ b/workflows/workflow_use/healing/prompts/workflow_creation_prompt.md
@@ -23,10 +23,10 @@ You are a master at building re-executable workflows from browser automation ste
    - Use `{{variable}}` syntax (one pair of curly braces) in `target_text` for dynamic values
    - Example: `{{"type": "click", "target_text": "{{repo_name}}"}}`
 
-4. **Variables MUST use {variable} syntax (one pair of curly braces)**
+4. **Variables MUST use {{variable}} syntax (one pair of curly braces)**
    - ✅ CORRECT: `"value": "{{email}}"` or `"target_text": "{{repo_name}}"`
    - ❌ WRONG: `"value": "{{{{email}}}}"` or `"value": "email"`
-   - Python's str.format() substitutes {variable} with actual values at runtime
+   - Python's str.format() substitutes {{variable}} with actual values at runtime
 
 5. **Prefer direct navigation over search engines!**
    - If task involves "search GitHub" → Navigate directly to https://github.com


### PR DESCRIPTION
## Bug

`workflow_use/healing/prompts/workflow_creation_prompt.md` lines 26/29 contain single-braced `{variable}` while every other placeholder in the file is correctly escaped as `{{...}}`. The template is rendered with `str.format(goal=..., actions=...)` (`healing/service.py:296`), so **every call raises `KeyError('variable')`**.

Reproduce without any LLM key:

```python
from pathlib import Path
content = Path('workflows/workflow_use/healing/prompts/workflow_creation_prompt.md').read_text()
content.format(goal='g', actions='a')   # KeyError: 'variable'
```

## Impact

`create_workflow_definition` crashes **after** the browser agent has fully run — this is the default path of `generate_workflow_from_prompt` (`HealingService(use_deterministic_conversion=False)`, used by the CLI), so every generation attempt burns a complete agent session + LLM cost and then dies.

## Fix

Escape the two stray placeholders to `{{variable}}`. After rendering, the LLM still sees the intended single-braced `{variable}` example text.

## Note

Found while auditing the replay/generation pipeline (see #165 for the recording-side findings). Happy to split or adjust if you'd like this folded into something larger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escaped two stray `{variable}` placeholders in `workflow_use/healing/prompts/workflow_creation_prompt.md` to `{{variable}}` to stop `KeyError` from `str.format`. This fixes workflow generation crashes after the browser agent completes and avoids wasted sessions and cost.

<sup>Written for commit cf7d6bf61b38e68234edbeea8766c05a5e919184. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/workflow-use/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

