### PR TITLE
fix(replay): port the engine to browser-use 0.13's CDP actor API (deterministic replay was 100% dead)

### DIFF
--- a/workflows/pyproject.toml
+++ b/workflows/pyproject.toml
@@ -35,7 +35,6 @@ dev-dependencies = [
     "build==1.2.2.post1",
     "ruff==0.11.12",
     "pytest==8.4.2",
-    "pytest-asyncio==1.2.0",
 ]
 # Security constraints for transitive dependencies (pulled in by browser-use
 # and friends). Each floor lifts the resolved version out of a vulnerable range.
@@ -98,6 +97,3 @@ include = [
 [tool.hatch.metadata]
 allow-direct-references = true
 
-[tool.pytest.ini_options]
-asyncio_mode = "auto"
-testpaths = ["tests"]

--- a/workflows/pyproject.toml
+++ b/workflows/pyproject.toml
@@ -97,3 +97,7 @@ include = [
 
 [tool.hatch.metadata]
 allow-direct-references = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/workflows/pyproject.toml
+++ b/workflows/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
 dev-dependencies = [
     "build==1.2.2.post1",
     "ruff==0.11.12",
+    "pytest==8.4.2",
+    "pytest-asyncio==1.2.0",
 ]
 # Security constraints for transitive dependencies (pulled in by browser-use
 # and friends). Each floor lifts the resolved version out of a vulnerable range.

--- a/workflows/tests/test_browser_use_contract.py
+++ b/workflows/tests/test_browser_use_contract.py
@@ -133,10 +133,10 @@ class TestCdpSurfaceContract:
 FORBIDDEN_PATTERNS: list[tuple[str, str]] = [
 	(r'\.locator\(', 'Page.locator does not exist on the CDP actor Page'),
 	(r'\bpage\.wait_for_selector\(', 'Page.wait_for_selector does not exist'),
-	(r'\.wait_for_load_state\(', 'Page.wait_for_load_state does not exist'),
+	(r'(?<!cdp)\.wait_for_load_state\(', 'Page.wait_for_load_state does not exist'),
 	(r'\bpage\.check\(', 'Page.check does not exist (use Element.check)'),
 	(r'\bpage\.uncheck\(', 'Page.uncheck does not exist (use compat set_checkbox_state)'),
-	(r'\.query_selector_all\(', 'query_selector_all does not exist (use get_elements_by_css_selector)'),
+	(r'(?<!cdp)\.query_selector_all\(', 'query_selector_all does not exist (use get_elements_by_css_selector)'),
 	(r'(?<!asyncio)\.wait_for\(', 'Locator.wait_for does not exist (use compat wait_for_element)'),
 	(r'select_option\(\s*label=', 'Element.select_option takes values only, no label='),
 	(r'\.click\(\s*force=', 'Element.click takes no force= kwarg'),

--- a/workflows/tests/test_browser_use_contract.py
+++ b/workflows/tests/test_browser_use_contract.py
@@ -1,0 +1,177 @@
+"""API-contract tests between workflow-use and the pinned browser-use version.
+
+workflow-use replays workflows through browser-use's CDP actor API. Historically the
+engine was written against Playwright's API (page.locator, wait_for_selector,
+page.check, query_selector_all, ...) which does NOT exist on the CDP actor surface —
+every such call raises AttributeError at runtime, usually swallowed by broad excepts,
+so entire subsystems fail silently.
+
+These tests are import-time only (no browser is launched) and guard both directions:
+
+1. ``TestCdpSurfaceContract`` — every browser-use attribute the engine relies on must
+   exist with a compatible signature. If a browser-use upgrade changes the surface,
+   this fails at CI time instead of silently at replay time.
+2. ``TestNoPlaywrightIsms`` — a static scan asserting the engine never calls
+   Playwright-only APIs outside the dedicated CDP compatibility layer
+   (``workflow_use/compat/cdp.py``). This prevents the bug class from regressing.
+
+Run with: ``uv run pytest tests/test_browser_use_contract.py``
+"""
+
+import inspect
+import re
+from pathlib import Path
+
+from browser_use import Browser
+from browser_use.actor.element import Element
+from browser_use.actor.page import Page
+from browser_use.dom.views import EnhancedDOMTreeNode
+from browser_use.llm.views import ChatInvokeCompletion
+from browser_use.tools.service import Tools
+
+WORKFLOW_USE_ROOT = Path(__file__).resolve().parent.parent / 'workflow_use'
+
+
+class TestCdpSurfaceContract:
+	"""Everything the replay engine calls on browser-use must exist."""
+
+	def test_page_methods_exist(self):
+		required = [
+			'goto',
+			'evaluate',
+			'press',
+			'get_elements_by_css_selector',
+			'get_url',
+			'get_title',
+			'screenshot',
+			'must_get_element_by_prompt',
+		]
+		missing = [name for name in required if not hasattr(Page, name)]
+		assert not missing, f'browser-use Page lost methods the engine depends on: {missing}'
+
+	def test_element_methods_exist(self):
+		required = ['click', 'fill', 'focus', 'check', 'select_option', 'evaluate', 'get_attribute', 'hover', 'get_bounding_box']
+		missing = [name for name in required if not hasattr(Element, name)]
+		assert not missing, f'browser-use Element lost methods the engine depends on: {missing}'
+
+	def test_browser_session_methods_exist(self):
+		required = ['start', 'stop', 'get_current_page', 'get_browser_state_summary', 'get_selector_map']
+		missing = [name for name in required if not hasattr(Browser, name)]
+		assert not missing, f'browser-use Browser lost methods the engine depends on: {missing}'
+
+	def test_element_click_takes_no_force_kwarg(self):
+		"""Element.click has (button, click_count, modifiers) — Playwright's force= must not be passed."""
+		params = inspect.signature(Element.click).parameters
+		assert 'force' not in params, 'Element.click grew a force= kwarg; revisit cdp compat layer'
+		assert 'button' in params and 'click_count' in params
+
+	def test_element_select_option_takes_values_only(self):
+		"""Element.select_option accepts values only — Playwright's label=/index= do not exist."""
+		params = list(inspect.signature(Element.select_option).parameters)
+		assert params == ['self', 'values'], f'Element.select_option signature changed: {params}'
+
+	def test_page_evaluate_returns_json_string(self):
+		"""Page.evaluate JSON-stringifies results — callers must json.loads, never treat as dict."""
+		sig = inspect.signature(Page.evaluate)
+		assert sig.return_annotation in ('str', str), f'Page.evaluate return annotation changed: {sig.return_annotation}'
+
+	def test_page_screenshot_returns_base64_not_path(self):
+		"""Page.screenshot returns base64 str; Playwright's path=/full_page= kwargs do not exist."""
+		params = inspect.signature(Page.screenshot).parameters
+		assert 'path' not in params, 'Page.screenshot grew a path= kwarg; revisit call sites'
+		sig = inspect.signature(Page.screenshot)
+		assert sig.return_annotation in ('str', str)
+
+	def test_playwright_only_page_methods_still_absent(self):
+		"""If browser-use ever adds these, the compat layer can be simplified — flag it."""
+		playwright_only = ['locator', 'wait_for_selector', 'wait_for_load_state', 'check', 'uncheck', 'query_selector_all']
+		appeared = [name for name in playwright_only if hasattr(Page, name)]
+		assert not appeared, f'browser-use Page now provides {appeared}; simplify workflow_use/compat/cdp.py'
+
+	def test_dom_node_fields(self):
+		"""Element finders read these fields; EnhancedDOMTreeNode is slotted so typos = dead code."""
+		fields = set(EnhancedDOMTreeNode.__dataclass_fields__.keys())
+		required = {'node_value', 'attributes', 'ax_node', 'is_visible', 'children_nodes'}
+		missing = required - fields
+		assert not missing, f'EnhancedDOMTreeNode lost fields the element finder reads: {missing}'
+		# tag_name/xpath are properties, not dataclass fields
+		for prop in ('tag_name', 'xpath'):
+			assert hasattr(EnhancedDOMTreeNode, prop), f'EnhancedDOMTreeNode.{prop} disappeared'
+		assert hasattr(EnhancedDOMTreeNode, 'get_all_children_text'), 'text extraction depends on get_all_children_text()'
+
+	def test_dom_node_has_no_flat_text_attributes(self):
+		"""Guard against regressing to getattr(node, 'text'/'aria_label'/...) which silently returns ''."""
+		fields = set(EnhancedDOMTreeNode.__dataclass_fields__.keys())
+		idealized = {'text', 'aria_label', 'placeholder', 'title', 'alt', 'inner_text', 'css_selector'}
+		appeared = idealized & fields
+		assert not appeared, f'EnhancedDOMTreeNode now has {appeared}; element finder fallbacks can be simplified'
+
+	def test_llm_completion_field(self):
+		"""LLM responses expose .completion (not LangChain's .content)."""
+		fields = set(ChatInvokeCompletion.model_fields.keys())
+		assert 'completion' in fields, 'ChatInvokeCompletion.completion disappeared'
+		assert 'content' not in fields, 'ChatInvokeCompletion grew .content; audit call sites reading it'
+
+	def test_builtin_action_names(self):
+		"""Actions the engine constructs/excludes by name must exist in the registry."""
+		registry_names = set(Tools().registry.registry.actions.keys())
+		relied_upon = {'go_back', 'click', 'input', 'scroll', 'navigate', 'send_keys', 'upload_file', 'extract'}
+		missing = relied_upon - registry_names
+		assert not missing, f'browser-use registry lost actions: {missing} (have: {sorted(registry_names)})'
+
+	def test_go_forward_still_not_builtin(self):
+		"""GoForwardStep needs the custom controller action while browser-use lacks a builtin."""
+		registry_names = set(Tools().registry.registry.actions.keys())
+		assert 'go_forward' not in registry_names, (
+			'browser-use now ships go_forward; the custom controller action can delegate to it'
+		)
+
+
+# --- Static scan -------------------------------------------------------------------
+
+# Playwright-only patterns that raise AttributeError/TypeError on the CDP actor surface.
+FORBIDDEN_PATTERNS: list[tuple[str, str]] = [
+	(r'\.locator\(', 'Page.locator does not exist on the CDP actor Page'),
+	(r'\bpage\.wait_for_selector\(', 'Page.wait_for_selector does not exist'),
+	(r'\.wait_for_load_state\(', 'Page.wait_for_load_state does not exist'),
+	(r'\bpage\.check\(', 'Page.check does not exist (use Element.check)'),
+	(r'\bpage\.uncheck\(', 'Page.uncheck does not exist (use compat set_checkbox_state)'),
+	(r'\.query_selector_all\(', 'query_selector_all does not exist (use get_elements_by_css_selector)'),
+	(r'(?<!asyncio)\.wait_for\(', 'Locator.wait_for does not exist (use compat wait_for_element)'),
+	(r'select_option\(\s*label=', 'Element.select_option takes values only, no label='),
+	(r'\.click\(\s*force=', 'Element.click takes no force= kwarg'),
+	(r'\.is_visible\(\)', 'ElementHandle.is_visible does not exist on CDP Element'),
+	(r'\.text_content\(\)', 'ElementHandle.text_content does not exist on CDP Element'),
+	(r'\.inner_text\(\)', 'ElementHandle.inner_text does not exist on CDP Element'),
+	(r'screenshot\(\s*path=', 'Page.screenshot returns base64; it takes no path= kwarg'),
+]
+
+# The compatibility layer is the single place allowed to know about surface differences.
+SCAN_EXEMPT = {'compat/cdp.py'}
+
+
+def iter_engine_files():
+	for path in sorted(WORKFLOW_USE_ROOT.rglob('*.py')):
+		rel = path.relative_to(WORKFLOW_USE_ROOT).as_posix()
+		if rel in SCAN_EXEMPT or '/tests/' in f'/{rel}':
+			continue
+		yield rel, path
+
+
+class TestNoPlaywrightIsms:
+	"""The engine must not call Playwright-only APIs outside workflow_use/compat/cdp.py."""
+
+	def test_no_playwright_calls_in_engine(self):
+		violations: list[str] = []
+		for rel, path in iter_engine_files():
+			text = path.read_text(encoding='utf-8')
+			for lineno, line in enumerate(text.splitlines(), start=1):
+				stripped = line.strip()
+				if stripped.startswith('#'):
+					continue
+				for pattern, why in FORBIDDEN_PATTERNS:
+					if re.search(pattern, line):
+						violations.append(f'{rel}:{lineno}: {stripped[:90]}  <-- {why}')
+		assert not violations, 'Playwright-only API calls found (each raises at runtime on browser-use CDP):\n' + '\n'.join(
+			violations
+		)

--- a/workflows/uv.lock
+++ b/workflows/uv.lock
@@ -5159,19 +5159,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-asyncio"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
-]
-
-[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -5908,7 +5895,6 @@ dependencies = [
 dev = [
     { name = "build" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -5931,7 +5917,6 @@ requires-dist = [
 dev = [
     { name = "build", specifier = "==1.2.2.post1" },
     { name = "pytest", specifier = "==8.4.2" },
-    { name = "pytest-asyncio", specifier = "==1.2.0" },
     { name = "ruff", specifier = "==0.11.12" },
 ]
 

--- a/workflows/uv.lock
+++ b/workflows/uv.lock
@@ -1146,11 +1146,20 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.12'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -1912,6 +1921,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -5125,6 +5143,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -5500,8 +5547,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "jeepney", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -5860,6 +5907,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "build" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -5881,6 +5930,8 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "build", specifier = "==1.2.2.post1" },
+    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest-asyncio", specifier = "==1.2.0" },
     { name = "ruff", specifier = "==0.11.12" },
 ]
 

--- a/workflows/workflow_use/compat/__init__.py
+++ b/workflows/workflow_use/compat/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility layers between workflow-use and the pinned browser-use version."""

--- a/workflows/workflow_use/compat/cdp.py
+++ b/workflows/workflow_use/compat/cdp.py
@@ -18,6 +18,7 @@ import asyncio
 import base64
 import json
 import logging
+import secrets
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -76,14 +77,6 @@ async def element_text_content(element: 'Element') -> str:
 		return ''
 
 
-async def element_inner_text(element: 'Element') -> str:
-	"""Playwright ``inner_text()`` equivalent."""
-	try:
-		return str(await element.evaluate('() => this.innerText || ""'))
-	except Exception:
-		return ''
-
-
 async def query_selector_all(page: 'Page', selector: str) -> list['Element']:
 	"""Playwright ``query_selector_all`` equivalent; [] on invalid selector."""
 	try:
@@ -117,43 +110,102 @@ async def wait_for_element(
 		await asyncio.sleep(poll_interval_s)
 
 
-_XPATH_MARK_JS = """(xpath, marker) => {
+_MARKER_ATTR = 'data-workflow-use-match'
+
+_XPATH_MARK_JS = """(xpath, marker, token) => {
 	try {
 		const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
 		const node = result.singleNodeValue;
 		if (node && node.nodeType === Node.ELEMENT_NODE) {
-			node.setAttribute(marker, '1');
+			node.setAttribute(marker, token);
 			return true;
 		}
 	} catch (e) {}
 	return false;
 }"""
 
-_XPATH_MARKER_ATTR = 'data-workflow-use-xpath-match'
+
+async def _fetch_marked_element(page: 'Page', token: str) -> 'Element | None':
+	"""Fetch the element tagged with our per-lookup token and untag it."""
+	elements = await query_selector_all(page, f'[{_MARKER_ATTR}="{token}"]')
+	if not elements:
+		return None
+	element = elements[0]
+	try:
+		await element.evaluate(f"() => this.removeAttribute('{_MARKER_ATTR}')")
+	except Exception:
+		pass
+	return element
 
 
 async def get_element_by_xpath(page: 'Page', xpath: str, timeout_ms: float = 2000) -> 'Element | None':
 	"""Resolve an XPath to an Element handle.
 
 	The CDP actor API only queries by CSS, so the matched node is tagged with a
-	temporary attribute, fetched by CSS, then untagged.
+	temporary attribute, fetched by CSS, then untagged. The marker value is a
+	per-lookup token so overlapping lookups can't select each other's element.
 	"""
 	deadline = asyncio.get_event_loop().time() + max(timeout_ms, 0) / 1000
 	while True:
+		token = secrets.token_hex(6)
 		try:
-			found = await evaluate(page, _XPATH_MARK_JS, xpath, _XPATH_MARKER_ATTR)
+			found = await evaluate(page, _XPATH_MARK_JS, xpath, _MARKER_ATTR, token)
 			if found is True:
-				elements = await query_selector_all(page, f'[{_XPATH_MARKER_ATTR}]')
-				if elements:
-					element = elements[0]
-					try:
-						await element.evaluate(f"() => this.removeAttribute('{_XPATH_MARKER_ATTR}')")
-					except Exception:
-						pass
-					if await element_is_visible(element):
-						return element
+				element = await _fetch_marked_element(page, token)
+				if element is not None and await element_is_visible(element):
+					return element
 		except Exception as e:
 			logger.debug(f'get_element_by_xpath({xpath!r}) failed: {e}')
+		if asyncio.get_event_loop().time() >= deadline:
+			return None
+		await asyncio.sleep(DEFAULT_POLL_INTERVAL_S)
+
+
+_TEXT_MATCH_MARK_JS = """(tag, wanted, marker, token) => {
+	const norm = (s) => (s || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+	const target = norm(wanted);
+	if (!target) return false;
+	let candidates;
+	try { candidates = document.querySelectorAll(tag); } catch (e) { return false; }
+	for (const el of candidates) {
+		const rect = el.getBoundingClientRect();
+		const style = getComputedStyle(el);
+		const visible = rect.width > 0 && rect.height > 0 && style.visibility !== 'hidden' && style.display !== 'none';
+		if (!visible) continue;
+		const haystacks = [
+			el.innerText,
+			el.getAttribute('aria-label'),
+			el.getAttribute('title'),
+			el.getAttribute('placeholder'),
+			el.value,
+		];
+		if (haystacks.some((h) => norm(h).includes(target))) {
+			el.setAttribute(marker, token);
+			return true;
+		}
+	}
+	return false;
+}"""
+
+
+async def find_element_by_text(page: 'Page', tag: str, text: str, timeout_ms: float = 2000) -> 'Element | None':
+	"""Find a visible *tag* element whose rendered text or accessible attributes contain *text*.
+
+	One page-side pass over ALL candidates (rendered ``innerText`` - not hidden
+	``textContent`` - plus aria-label/title/placeholder/value), polled until the
+	deadline so late-rendering elements are still found.
+	"""
+	deadline = asyncio.get_event_loop().time() + max(timeout_ms, 0) / 1000
+	while True:
+		token = secrets.token_hex(6)
+		try:
+			found = await evaluate(page, _TEXT_MATCH_MARK_JS, tag, text, _MARKER_ATTR, token)
+			if found is True:
+				element = await _fetch_marked_element(page, token)
+				if element is not None:
+					return element
+		except Exception as e:
+			logger.debug(f'find_element_by_text({tag!r}, {text!r}) failed: {e}')
 		if asyncio.get_event_loop().time() >= deadline:
 			return None
 		await asyncio.sleep(DEFAULT_POLL_INTERVAL_S)

--- a/workflows/workflow_use/compat/cdp.py
+++ b/workflows/workflow_use/compat/cdp.py
@@ -1,0 +1,254 @@
+"""CDP compatibility layer for browser-use's actor API.
+
+The replay engine was originally written against Playwright's Page/Locator API.
+browser-use >= 0.2 exposes a CDP-based actor surface instead: no ``page.locator``,
+``wait_for_selector``, ``wait_for_load_state``, ``page.check``/``uncheck``,
+``query_selector_all``; ``evaluate`` requires arrow-function source and returns a
+*string* (objects/arrays JSON-stringified, booleans as ``'True'``/``'False'``);
+``screenshot`` returns base64 instead of writing to a path.
+
+This module is the single place that knows those differences. Engine code imports
+the primitives below; ``tests/test_browser_use_contract.py`` statically enforces
+that no Playwright-only call exists outside this file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+	from browser_use.actor.element import Element
+	from browser_use.actor.page import Page
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_POLL_INTERVAL_S = 0.1
+
+_VISIBILITY_JS = (
+	'() => { const r = this.getBoundingClientRect(); const s = getComputedStyle(this); '
+	"return r.width > 0 && r.height > 0 && s.visibility !== 'hidden' && s.display !== 'none'; }"
+)
+
+
+def parse_js_result(raw: str | None) -> Any:
+	"""Decode the string returned by Page.evaluate / Element.evaluate.
+
+	browser-use stringifies every result: ``None`` -> ``''``, JS strings pass
+	through raw, dict/list are JSON-encoded, numbers/booleans go through
+	``str()`` (so JS ``true`` arrives as ``'True'``).
+	"""
+	if raw is None or raw == '':
+		return None
+	if raw == 'True':
+		return True
+	if raw == 'False':
+		return False
+	try:
+		return json.loads(raw)
+	except (ValueError, TypeError):
+		return raw
+
+
+async def evaluate(page_or_element: 'Page | Element', page_function: str, *args: Any) -> Any:
+	"""Run JS through the actor API and return a decoded Python value."""
+	raw = await page_or_element.evaluate(page_function, *args)
+	return parse_js_result(raw)
+
+
+async def element_is_visible(element: 'Element') -> bool:
+	"""Playwright ``is_visible()`` equivalent (geometry + computed style)."""
+	try:
+		return await evaluate(element, _VISIBILITY_JS) is True
+	except Exception:
+		return False
+
+
+async def element_text_content(element: 'Element') -> str:
+	"""Playwright ``text_content()`` equivalent."""
+	try:
+		return str(await element.evaluate('() => this.textContent || ""'))
+	except Exception:
+		return ''
+
+
+async def element_inner_text(element: 'Element') -> str:
+	"""Playwright ``inner_text()`` equivalent."""
+	try:
+		return str(await element.evaluate('() => this.innerText || ""'))
+	except Exception:
+		return ''
+
+
+async def query_selector_all(page: 'Page', selector: str) -> list['Element']:
+	"""Playwright ``query_selector_all`` equivalent; [] on invalid selector."""
+	try:
+		return await page.get_elements_by_css_selector(selector)
+	except Exception as e:
+		logger.debug(f'query_selector_all({selector!r}) failed: {e}')
+		return []
+
+
+async def wait_for_element(
+	page: 'Page',
+	selector: str,
+	timeout_ms: float = 2000,
+	state: str = 'visible',
+	poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+) -> 'Element | None':
+	"""Playwright ``wait_for_selector`` equivalent.
+
+	Polls until an element matching *selector* is attached (``state='attached'``)
+	or visible (``state='visible'``). Returns the element, or None on timeout —
+	callers decide whether that is an error.
+	"""
+	deadline = asyncio.get_event_loop().time() + max(timeout_ms, 0) / 1000
+	while True:
+		elements = await query_selector_all(page, selector)
+		for element in elements:
+			if state != 'visible' or await element_is_visible(element):
+				return element
+		if asyncio.get_event_loop().time() >= deadline:
+			return None
+		await asyncio.sleep(poll_interval_s)
+
+
+_XPATH_MARK_JS = """(xpath, marker) => {
+	try {
+		const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+		const node = result.singleNodeValue;
+		if (node && node.nodeType === Node.ELEMENT_NODE) {
+			node.setAttribute(marker, '1');
+			return true;
+		}
+	} catch (e) {}
+	return false;
+}"""
+
+_XPATH_MARKER_ATTR = 'data-workflow-use-xpath-match'
+
+
+async def get_element_by_xpath(page: 'Page', xpath: str, timeout_ms: float = 2000) -> 'Element | None':
+	"""Resolve an XPath to an Element handle.
+
+	The CDP actor API only queries by CSS, so the matched node is tagged with a
+	temporary attribute, fetched by CSS, then untagged.
+	"""
+	deadline = asyncio.get_event_loop().time() + max(timeout_ms, 0) / 1000
+	while True:
+		try:
+			found = await evaluate(page, _XPATH_MARK_JS, xpath, _XPATH_MARKER_ATTR)
+			if found is True:
+				elements = await query_selector_all(page, f'[{_XPATH_MARKER_ATTR}]')
+				if elements:
+					element = elements[0]
+					try:
+						await element.evaluate(f"() => this.removeAttribute('{_XPATH_MARKER_ATTR}')")
+					except Exception:
+						pass
+					if await element_is_visible(element):
+						return element
+		except Exception as e:
+			logger.debug(f'get_element_by_xpath({xpath!r}) failed: {e}')
+		if asyncio.get_event_loop().time() >= deadline:
+			return None
+		await asyncio.sleep(DEFAULT_POLL_INTERVAL_S)
+
+
+async def wait_for_load_state(page: 'Page', state: str = 'load', timeout_ms: float = 10000) -> bool:
+	"""Approximate Playwright ``wait_for_load_state`` on the CDP surface.
+
+	Polls ``document.readyState``. ``'networkidle'`` additionally requires the
+	ready state to hold for a short settle window (the actor API exposes no
+	network-inflight signal). Returns False on timeout instead of raising.
+	"""
+	target_states = ('interactive', 'complete') if state == 'domcontentloaded' else ('complete',)
+	settle_s = 0.5 if state == 'networkidle' else 0.0
+	deadline = asyncio.get_event_loop().time() + max(timeout_ms, 0) / 1000
+	settled_since: float | None = None
+	while True:
+		try:
+			ready = await evaluate(page, '() => document.readyState')
+		except Exception:
+			ready = None  # mid-navigation; keep polling
+		now = asyncio.get_event_loop().time()
+		if ready in target_states:
+			if settle_s == 0.0:
+				return True
+			if settled_since is None:
+				settled_since = now
+			elif now - settled_since >= settle_s:
+				return True
+		else:
+			settled_since = None
+		if now >= deadline:
+			return False
+		await asyncio.sleep(DEFAULT_POLL_INTERVAL_S)
+
+
+async def screenshot_to_file(page: 'Page', path: str, format: str = 'png') -> None:
+	"""Playwright ``screenshot(path=...)`` equivalent: decode base64 and write."""
+	data = await page.screenshot(format=format)
+	raw = base64.b64decode(data)
+	await asyncio.to_thread(Path(path).write_bytes, raw)
+
+
+async def is_checked(element: 'Element') -> bool:
+	return await evaluate(element, '() => !!this.checked') is True
+
+
+async def set_checkbox_state(element: 'Element', checked: bool) -> bool:
+	"""Playwright ``check()``/``uncheck()`` equivalent via user-like clicks.
+
+	Returns True when the element ends up in the desired state.
+	"""
+	current = await is_checked(element)
+	if current == checked:
+		return True
+	await element.click()
+	return await is_checked(element) == checked
+
+
+async def is_select_element(element: 'Element') -> bool:
+	return await evaluate(element, "() => this.tagName === 'SELECT'") is True
+
+
+_SELECT_BY_TEXT_JS = """(wanted) => {
+	if (this.tagName !== 'SELECT') return 'not-select';
+	const norm = (s) => (s || '').replace(/\\s+/g, ' ').trim();
+	const target = norm(wanted);
+	const options = Array.from(this.options);
+	let index = options.findIndex((o) => norm(o.label) === target || norm(o.textContent) === target);
+	if (index === -1) index = options.findIndex((o) => norm(o.value) === target);
+	if (index === -1) return 'no-match';
+	if (this.selectedIndex !== index) {
+		this.selectedIndex = index;
+		this.dispatchEvent(new Event('input', { bubbles: true }));
+		this.dispatchEvent(new Event('change', { bubbles: true }));
+	}
+	return 'ok';
+}"""
+
+
+async def select_option_by_text(element: 'Element', text: str) -> bool:
+	"""Select a ``<select>`` option by visible label (fallback: value attribute).
+
+	``Element.select_option`` matches option *values* and cannot see option label
+	text (element-node nodeValue is empty at depth 1), so visible-text selection
+	is implemented in page JS with proper input/change events.
+	"""
+	result = await evaluate(element, _SELECT_BY_TEXT_JS, text)
+	if result == 'ok':
+		return True
+	logger.debug(f'select_option_by_text({text!r}) -> {result}')
+	return False
+
+
+async def press_key_on_element(page: 'Page', element: 'Element', key: str) -> None:
+	"""Playwright ``locator.press`` equivalent: focus the element, press on page."""
+	await element.focus()
+	await page.press(key)

--- a/workflows/workflow_use/controller/service.py
+++ b/workflows/workflow_use/controller/service.py
@@ -5,7 +5,9 @@ from browser_use import Browser
 from browser_use.agent.views import ActionResult
 from browser_use.controller import Controller
 from browser_use.llm.base import BaseChatModel
+from browser_use.tools.views import NoParamsAction
 
+from workflow_use.compat import cdp
 from workflow_use.controller.utils import get_best_element_handle, truncate_selector
 from workflow_use.controller.views import (
 	ClickElementDeterministicAction,
@@ -21,41 +23,27 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_ACTION_TIMEOUT_MS = 1000
 
-# List of default actions from browser_use.controller.service.Controller to disable
-# todo: come up with a better way to filter out the actions (filter IN the actions would be much nicer in this case)
-DISABLED_DEFAULT_ACTIONS = [
-	'done',
-	'search_google',
-	'go_to_url',  # I am using this action from the main controller to avoid duplication
-	'go_back',
-	'wait',
-	'click_element_by_index',
-	'input_text',
-	'save_pdf',
-	'switch_tab',
-	'open_tab',
-	'close_tab',
-	'extract_content',
-	'scroll_down',
-	'scroll_up',
-	'send_keys',
-	'scroll_to_text',
-	'get_dropdown_options',
-	'select_dropdown_option',
-	'drag_drop',
-	'get_sheet_contents',
-	'select_cell_or_range',
-	'get_range_contents',
-	'clear_selected_range',
-	'input_selected_cell_text',
-	'update_range_contents',
-]
+
+# The WorkflowController executes deterministic workflow steps only; agentic steps
+# run through their own Agent with a separate controller. Every browser-use builtin
+# is therefore excluded so that (a) the registry contains exactly the deterministic
+# step vocabulary, (b) our custom 'click'/'input'/'scroll' registrations don't rely
+# on silently overwriting builtins of the same name, and (c) the builder prompt
+# (which lists this registry) can only suggest step types the schema accepts.
+def _all_builtin_action_names() -> list[str]:
+	from browser_use.tools.service import Tools
+
+	return list(Tools().registry.registry.actions.keys())
 
 
 class WorkflowController(Controller):
 	def __init__(self, *args, **kwargs):
-		# Pass the list of actions to exclude to the base class constructor
-		super().__init__(*args, exclude_actions=DISABLED_DEFAULT_ACTIONS, **kwargs)
+		# Exclude every builtin (allowlist style): only actions registered below exist.
+		super().__init__(*args, exclude_actions=_all_builtin_action_names(), **kwargs)
+		# The exclusion list also applies to our own registrations below (several
+		# reuse builtin names like 'click'/'input'/'scroll'); clear it now that the
+		# builtins have been filtered out.
+		self.registry.exclude_actions = []
 		self.__register_actions()
 
 	def __register_actions(self):
@@ -65,12 +53,29 @@ class WorkflowController(Controller):
 			"""Navigate to the given URL."""
 			page = await browser_session.get_current_page()
 			await page.goto(params.url)
-			# Wait for page to load (CDP navigate doesn't wait automatically)
-			import asyncio
-
-			await asyncio.sleep(2)
+			# CDP navigate doesn't wait automatically; wait for the document to load.
+			await cdp.wait_for_load_state(page, 'load', timeout_ms=10000)
 
 			msg = f'🔗  Navigated to URL: {params.url}'
+			logger.info(msg)
+			return ActionResult(extracted_content=msg, include_in_memory=True)
+
+		# History navigation --------------------------------------------------------
+		@self.registry.action('Go back to the previous page', param_model=NoParamsAction)
+		async def go_back(_: NoParamsAction, browser_session: Browser) -> ActionResult:
+			page = await browser_session.get_current_page()
+			await page.go_back()
+			await cdp.wait_for_load_state(page, 'load', timeout_ms=10000)
+			msg = '🔙  Navigated back'
+			logger.info(msg)
+			return ActionResult(extracted_content=msg, include_in_memory=True)
+
+		@self.registry.action('Go forward to the next page', param_model=NoParamsAction)
+		async def go_forward(_: NoParamsAction, browser_session: Browser) -> ActionResult:
+			page = await browser_session.get_current_page()
+			await page.go_forward()
+			await cdp.wait_for_load_state(page, 'load', timeout_ms=10000)
+			msg = '🔜  Navigated forward'
 			logger.info(msg)
 			return ActionResult(extracted_content=msg, include_in_memory=True)
 
@@ -86,13 +91,13 @@ class WorkflowController(Controller):
 			original_selector = params.cssSelector
 
 			try:
-				locator, selector_used = await get_best_element_handle(
+				element, selector_used = await get_best_element_handle(
 					page,
 					params.cssSelector,
 					params,
 					timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
 				)
-				await locator.click(force=True)
+				await element.click()
 
 				msg = f'🖱️  Clicked element with CSS selector: {truncate_selector(selector_used)} (original: {truncate_selector(original_selector)})'
 				logger.info(msg)
@@ -117,25 +122,21 @@ class WorkflowController(Controller):
 			original_selector = params.cssSelector
 
 			try:
-				locator, selector_used = await get_best_element_handle(
+				element, selector_used = await get_best_element_handle(
 					page,
 					params.cssSelector,
 					params,
 					timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
 				)
 
-				# Check if it's a SELECT element
-				is_select = await locator.evaluate('(el) => el.tagName === "SELECT"')
-				if is_select:
+				# Check if it's a SELECT element (select values are set via select_change)
+				if await cdp.is_select_element(element):
 					return ActionResult(
 						extracted_content='Ignored input into select element',
 						include_in_memory=True,
 					)
 
-				# Add a small delay and click to ensure the element is focused
-				await locator.fill(params.value)
-				await asyncio.sleep(0.5)
-				await locator.click(force=True)
+				await element.fill(params.value)
 				await asyncio.sleep(0.5)
 
 				msg = f'⌨️  Input "{params.value}" into element with CSS selector: {truncate_selector(selector_used)} (original: {truncate_selector(original_selector)})'
@@ -157,14 +158,16 @@ class WorkflowController(Controller):
 			original_selector = params.cssSelector
 
 			try:
-				locator, selector_used = await get_best_element_handle(
+				element, selector_used = await get_best_element_handle(
 					page,
 					params.cssSelector,
 					params,
 					timeout_ms=DEFAULT_ACTION_TIMEOUT_MS,
 				)
 
-				await locator.select_option(label=params.selectedText)
+				# Match by visible label text (Element.select_option only matches values)
+				if not await cdp.select_option_by_text(element, params.selectedText):
+					raise Exception(f'No option with visible text "{params.selectedText}" found')
 
 				msg = f'Selected option "{params.selectedText}" in dropdown {truncate_selector(selector_used)} (original: {truncate_selector(original_selector)})'
 				logger.info(msg)
@@ -185,9 +188,10 @@ class WorkflowController(Controller):
 			original_selector = params.cssSelector
 
 			try:
-				locator, selector_used = await get_best_element_handle(page, params.cssSelector, params, timeout_ms=5000)
+				element, selector_used = await get_best_element_handle(page, params.cssSelector, params, timeout_ms=5000)
 
-				await locator.press(params.key)
+				# Element has no press(); focus it and press on the page
+				await cdp.press_key_on_element(page, element, params.key)
 
 				msg = f"🔑  Pressed key '{params.key}' on element with CSS selector: {truncate_selector(selector_used)} (original: {truncate_selector(original_selector)})"
 				logger.info(msg)

--- a/workflows/workflow_use/controller/utils.py
+++ b/workflows/workflow_use/controller/utils.py
@@ -1,6 +1,8 @@
 import logging
 import re
 
+from workflow_use.compat import cdp
+
 logger = logging.getLogger(__name__)
 
 
@@ -9,41 +11,66 @@ def truncate_selector(selector: str, max_length: int = 35) -> str:
 	return selector if len(selector) <= max_length else f'{selector[:max_length]}...'
 
 
+async def _find_by_tag_and_text(page, tag: str, text: str, timeout_ms: float):
+	"""Text-based fallback: match a *tag* element whose visible text contains *text*.
+
+	(Replaces the Playwright-only ``:has-text()`` pseudo-class, which is not
+	valid CSS and throws in ``document.querySelectorAll``.)
+	"""
+	wanted = ' '.join(text.split()).lower()
+	if not wanted:
+		return None
+	elements = await cdp.query_selector_all(page, tag)
+	for element in elements[:40]:  # bound the scan on huge pages
+		try:
+			candidate = ' '.join((await cdp.element_text_content(element)).split()).lower()
+			if wanted in candidate and await cdp.element_is_visible(element):
+				return element
+		except Exception:
+			continue
+	return None
+
+
 async def get_best_element_handle(page, selector, params=None, timeout_ms=100):
-	"""Find element using stability-ranked selector strategies."""
+	"""Find an element using stability-ranked selector strategies.
+
+	Returns ``(element, selector_used)`` where *element* is a browser-use actor
+	``Element``. Raises when every strategy fails.
+	"""
 	original_selector = selector
 
 	# Generate stability-ranked fallback selectors
 	fallbacks = generate_stable_selectors(selector, params)
 
-	# Try all selectors with exponential backoff for timeouts
 	selectors_to_try = [original_selector] + fallbacks
 
 	for try_selector in selectors_to_try:
-		try:
-			logger.info(f'Trying selector: {truncate_selector(try_selector)}')
-			locator = page.locator(try_selector)
-			await locator.wait_for(state='visible', timeout=timeout_ms)
+		logger.info(f'Trying selector: {truncate_selector(try_selector)}')
+		element = await cdp.wait_for_element(page, try_selector, timeout_ms=timeout_ms)
+		if element is not None:
 			logger.info(f'Found element with selector: {truncate_selector(try_selector)}')
-			return locator, try_selector
-		except Exception as e:
-			logger.error(f'Selector failed: {truncate_selector(try_selector)} with error: {e}')
+			return element, try_selector
+		logger.debug(f'Selector failed: {truncate_selector(try_selector)}')
+
+	# Text-based fallback (tag + recorded element text)
+	element_tag = params.elementTag if params and getattr(params, 'elementTag', None) else None
+	element_text = params.elementText if params and getattr(params, 'elementText', None) else None
+	if element_tag and element_text and element_text.strip():
+		logger.info(f'Trying text fallback: <{element_tag}> containing "{element_text.strip()[:35]}"')
+		element = await _find_by_tag_and_text(page, element_tag.lower(), element_text, timeout_ms)
+		if element is not None:
+			return element, f'{element_tag.lower()}:text({element_text.strip()[:35]})'
 
 	# Try XPath as last resort
 	if params and getattr(params, 'xpath', None):
-		xpath = params.xpath
-		try:
-			# Generate stable XPath alternatives
-			xpath_alternatives = [xpath] + generate_stable_xpaths(xpath, params)
-
-			for try_xpath in xpath_alternatives:
-				xpath_selector = f'xpath={try_xpath}'
-				logger.info(f'Trying XPath: {truncate_selector(xpath_selector)}')
-				locator = page.locator(xpath_selector)
-				await locator.wait_for(state='visible', timeout=timeout_ms)
-				return locator, xpath_selector
-		except Exception as e:
-			logger.error(f'All XPaths failed with error: {e}')
+		xpath_alternatives = [params.xpath] + generate_stable_xpaths(params.xpath, params)
+		for try_xpath in xpath_alternatives:
+			xpath_selector = f'xpath={try_xpath}'
+			logger.info(f'Trying XPath: {truncate_selector(xpath_selector)}')
+			element = await cdp.get_element_by_xpath(page, try_xpath, timeout_ms=timeout_ms)
+			if element is not None:
+				return element, xpath_selector
+			logger.debug(f'XPath failed: {truncate_selector(xpath_selector)}')
 
 	raise Exception(f'Failed to find element. Original: {original_selector}')
 
@@ -94,9 +121,8 @@ def generate_stable_selectors(selector, params=None):
 		if state in selector:
 			fallbacks.append(selector.replace(state, ''))
 
-	# 5. Use text-based selector if we have element tag and text
-	if params and getattr(params, 'elementTag', None) and getattr(params, 'elementText', None) and params.elementText.strip():
-		fallbacks.append(f"{params.elementTag}:has-text('{params.elementText}')")
+	# NOTE: text-based fallback lives in get_best_element_handle/_find_by_tag_and_text;
+	# Playwright's :has-text() pseudo-class is not valid CSS on the CDP surface.
 
 	return list(dict.fromkeys(fallbacks))  # Remove duplicates while preserving order
 

--- a/workflows/workflow_use/controller/utils.py
+++ b/workflows/workflow_use/controller/utils.py
@@ -12,23 +12,16 @@ def truncate_selector(selector: str, max_length: int = 35) -> str:
 
 
 async def _find_by_tag_and_text(page, tag: str, text: str, timeout_ms: float):
-	"""Text-based fallback: match a *tag* element whose visible text contains *text*.
+	"""Text-based fallback: match a *tag* element by its recorded text.
 
-	(Replaces the Playwright-only ``:has-text()`` pseudo-class, which is not
-	valid CSS and throws in ``document.querySelectorAll``.)
+	Delegates to the compat finder: one page-side pass over ALL candidates
+	(rendered innerText plus aria-label/title/placeholder/value), polled until
+	*timeout_ms* so late-rendering elements are still found. (Replaces the
+	Playwright-only text pseudo-class, which is not valid CSS.)
 	"""
-	wanted = ' '.join(text.split()).lower()
-	if not wanted:
+	if not text.strip():
 		return None
-	elements = await cdp.query_selector_all(page, tag)
-	for element in elements[:40]:  # bound the scan on huge pages
-		try:
-			candidate = ' '.join((await cdp.element_text_content(element)).split()).lower()
-			if wanted in candidate and await cdp.element_is_visible(element):
-				return element
-		except Exception:
-			continue
-	return None
+	return await cdp.find_element_by_text(page, tag, text, timeout_ms=timeout_ms)
 
 
 async def get_best_element_handle(page, selector, params=None, timeout_ms=100):

--- a/workflows/workflow_use/workflow/element_finder.py
+++ b/workflows/workflow_use/workflow/element_finder.py
@@ -26,9 +26,18 @@ logger = logging.getLogger(__name__)
 
 
 def _node_attr(node: Any, name: str, default: str = '') -> str:
-	"""Read an HTML attribute from the node's attributes dict (dict nodes supported for tests)."""
+	"""Read an HTML attribute from the node's attributes dict.
+
+	Dict-form nodes are supported both flat ({'placeholder': ...}) and in
+	browser-use's nested shape ({'attributes': {'placeholder': ...}}).
+	"""
 	if isinstance(node, dict):
-		return str(node.get(name) or default)
+		value = node.get(name)
+		if value is None:
+			nested = node.get('attributes')
+			if isinstance(nested, dict):
+				value = nested.get(name)
+		return str(value) if value is not None else default
 	attrs = getattr(node, 'attributes', None) or {}
 	value = attrs.get(name)
 	return str(value) if value is not None else default

--- a/workflows/workflow_use/workflow/element_finder.py
+++ b/workflows/workflow_use/workflow/element_finder.py
@@ -12,9 +12,66 @@ import logging
 from difflib import SequenceMatcher
 from typing import Any, Dict, List, Optional, Tuple
 
+from workflow_use.compat import cdp
 from workflow_use.workflow.error_reporter import StrategyAttempt
 
 logger = logging.getLogger(__name__)
+
+
+# --- EnhancedDOMTreeNode accessors -------------------------------------------------
+# browser-use's EnhancedDOMTreeNode is a slotted dataclass WITHOUT flat convenience
+# attributes like .text/.aria_label/.placeholder — reading those via getattr silently
+# returns '' and no strategy can ever match. Real sources: the attributes dict, the
+# accessibility node, and get_all_children_text() for subtree text.
+
+
+def _node_attr(node: Any, name: str, default: str = '') -> str:
+	"""Read an HTML attribute from the node's attributes dict (dict nodes supported for tests)."""
+	if isinstance(node, dict):
+		return str(node.get(name) or default)
+	attrs = getattr(node, 'attributes', None) or {}
+	value = attrs.get(name)
+	return str(value) if value is not None else default
+
+
+def _node_ax(node: Any, field: str) -> str:
+	ax = getattr(node, 'ax_node', None)
+	value = getattr(ax, field, None) if ax is not None else None
+	return str(value) if value else ''
+
+
+def _node_text(node: Any) -> str:
+	"""Visible text of the node: subtree text first, accessible name as fallback."""
+	if isinstance(node, dict):
+		return str(node.get('text') or '')
+	try:
+		text = (node.get_all_children_text(max_depth=2) or '').strip()
+	except Exception:
+		text = ''
+	if not text:
+		text = _node_ax(node, 'name').strip()
+	if not text:
+		# Inputs/images carry their label in attributes rather than text children
+		text = (_node_attr(node, 'value') or _node_attr(node, 'alt') or _node_attr(node, 'title')).strip()
+	return text
+
+
+def _node_aria_label(node: Any) -> str:
+	if isinstance(node, dict):
+		return str(node.get('aria_label') or '')
+	return _node_attr(node, 'aria-label') or _node_ax(node, 'name')
+
+
+def _node_role(node: Any) -> str:
+	if isinstance(node, dict):
+		return str(node.get('role') or node.get('tag_name') or '')
+	return _node_attr(node, 'role') or _node_ax(node, 'role') or str(getattr(node, 'tag_name', '') or '')
+
+
+def _node_tag(node: Any) -> str:
+	if isinstance(node, dict):
+		return str(node.get('tag_name') or '')
+	return str(getattr(node, 'tag_name', '') or '')
 
 
 class ElementFinder:
@@ -303,51 +360,36 @@ class ElementFinder:
 		    True if node matches the strategy
 		"""
 		try:
-			# Helper to get attribute from dict or object
-			def get_attr(obj, attr, default=''):
-				if isinstance(obj, dict):
-					return obj.get(attr, default)
-				return getattr(obj, attr, default)
-
 			# Semantic Strategy 1: Exact text match
 			if strategy_type == 'text_exact':
-				node_text = get_attr(node, 'text', '') or ''
-				return node_text.strip() == value
+				return _node_text(node).strip() == value
 
 			# Semantic Strategy 2: Role + text
 			elif strategy_type == 'role_text':
 				expected_role = metadata.get('role', '').lower()
-				node_role = get_attr(node, 'role', '') or get_attr(node, 'tag_name', '')
-				node_role = node_role.lower() if node_role else ''
-				node_text = get_attr(node, 'text', '') or ''
-
-				return node_role == expected_role and node_text.strip() == value
+				node_role = _node_role(node).lower()
+				return node_role == expected_role and _node_text(node).strip() == value
 
 			# Semantic Strategy 3: ARIA label
 			elif strategy_type == 'aria_label':
-				aria_label = get_attr(node, 'aria_label', '') or ''
-				return aria_label.strip() == value
+				return _node_aria_label(node).strip() == value
 
 			# Semantic Strategy 4: Placeholder
 			elif strategy_type == 'placeholder':
-				placeholder = get_attr(node, 'placeholder', '') or ''
-				return placeholder.strip() == value
+				return _node_attr(node, 'placeholder').strip() == value
 
 			# Semantic Strategy 5: Title attribute
 			elif strategy_type == 'title':
-				title = get_attr(node, 'title', '') or ''
-				return title.strip() == value
+				return _node_attr(node, 'title').strip() == value
 
 			# Semantic Strategy 6: Alt text (images)
 			elif strategy_type == 'alt_text':
-				alt = get_attr(node, 'alt', '') or ''
-				return alt.strip() == value
+				return _node_attr(node, 'alt').strip() == value
 
 			# Semantic Strategy 7: Fuzzy text match
 			elif strategy_type == 'text_fuzzy':
 				threshold = metadata.get('threshold', 0.8)
-				node_text = get_attr(node, 'text', '') or ''
-				return self._fuzzy_match(value, node_text.strip(), threshold)
+				return self._fuzzy_match(value, _node_text(node).strip(), threshold)
 
 			# Note: XPath and CSS strategies are handled separately in find_element_with_strategies
 			# They cannot be matched against browser-use's node representation
@@ -376,8 +418,8 @@ class ElementFinder:
 		"""
 		try:
 			# Check if node is visible - this is a hard requirement
-			is_visible = getattr(node, 'is_visible', True)
-			if not is_visible:
+			# (is_visible is Optional on EnhancedDOMTreeNode; only explicit False rejects)
+			if getattr(node, 'is_visible', None) is False:
 				logger.debug(f'Element at index {index} is not visible')
 				return False
 
@@ -390,35 +432,16 @@ class ElementFinder:
 				# Collect all text sources from the element
 				text_sources = []
 
-				# Get element's visible text
-				node_text = getattr(node, 'text', '') or ''
-				if node_text:
-					text_sources.append(node_text.lower().strip())
-
-				# Get aria-label
-				aria_label = getattr(node, 'aria_label', '') or ''
-				if aria_label:
-					text_sources.append(aria_label.lower().strip())
-
-				# Get placeholder
-				placeholder = getattr(node, 'placeholder', '') or ''
-				if placeholder:
-					text_sources.append(placeholder.lower().strip())
-
-				# Get title
-				title = getattr(node, 'title', '') or ''
-				if title:
-					text_sources.append(title.lower().strip())
-
-				# Get alt text
-				alt = getattr(node, 'alt', '') or ''
-				if alt:
-					text_sources.append(alt.lower().strip())
-
-				# Get name attribute
-				attrs = getattr(node, 'attributes', {}) or {}
-				if 'name' in attrs:
-					text_sources.append(attrs['name'].lower().strip())
+				for source in (
+					_node_text(node),
+					_node_aria_label(node),
+					_node_attr(node, 'placeholder'),
+					_node_attr(node, 'title'),
+					_node_attr(node, 'alt'),
+					_node_attr(node, 'name'),
+				):
+					if source:
+						text_sources.append(source.lower().strip())
 
 				# Check if target_text matches any text source
 				found_match = any(target_lower in source or source in target_lower for source in text_sources if source)
@@ -501,7 +524,8 @@ class ElementFinder:
 	}}
 }}"""
 
-			result = await page.evaluate(js_code)
+			# Page.evaluate returns a JSON string; decode it before inspecting
+			result = await cdp.evaluate(page, js_code)
 
 			if not result:
 				logger.info('         ⚠️  XPath evaluation returned null')
@@ -544,14 +568,14 @@ class ElementFinder:
 			checks = 0
 
 			# Check tag name
-			node_tag = getattr(node, 'tag_name', '').lower()
+			node_tag = _node_tag(node).lower()
 			if node_tag and element_data.get('tagName'):
 				checks += 1
-				if node_tag == element_data['tagName']:
+				if node_tag == element_data['tagName'].lower():
 					matches += 1
 
 			# Check text content (allow partial match for robustness)
-			node_text = (getattr(node, 'text', '') or '').strip()
+			node_text = _node_text(node).strip()
 			element_text = element_data.get('text', '').strip()
 			if node_text and element_text:
 				checks += 1
@@ -559,31 +583,31 @@ class ElementFinder:
 					matches += 1
 
 			# Check ID
-			node_id = getattr(node, 'element_id', '') or ''
+			node_id = _node_attr(node, 'id')
 			if node_id and element_data.get('id'):
 				checks += 1
 				if node_id == element_data['id']:
 					matches += 2  # ID is a strong indicator
 
 			# Check aria-label
-			node_aria = getattr(node, 'aria_label', '') or ''
+			node_aria = _node_aria_label(node)
 			if node_aria and element_data.get('ariaLabel'):
 				checks += 1
 				if node_aria == element_data['ariaLabel']:
 					matches += 1
 
 			# Check placeholder
-			node_placeholder = getattr(node, 'placeholder', '') or ''
+			node_placeholder = _node_attr(node, 'placeholder')
 			if node_placeholder and element_data.get('placeholder'):
 				checks += 1
 				if node_placeholder == element_data['placeholder']:
 					matches += 1
 
 			# Check name attribute
-			node_attrs = getattr(node, 'attributes', {}) or {}
-			if 'name' in node_attrs and element_data.get('name'):
+			node_name = _node_attr(node, 'name')
+			if node_name and element_data.get('name'):
 				checks += 1
-				if node_attrs['name'] == element_data['name']:
+				if node_name == element_data['name']:
 					matches += 1
 
 			# Require at least 2 matches or 1 strong match (ID)

--- a/workflows/workflow_use/workflow/semantic_executor.py
+++ b/workflows/workflow_use/workflow/semantic_executor.py
@@ -145,12 +145,7 @@ class SemanticWorkflowExecutor:
 		if not elements:
 			logger.debug(f'_set_checked_by_selector: no element for {selector}')
 			return False
-		element = elements[0]
-		if await self._element_is_checked(element) == checked:
-			return True
-		await element.click()
-		await asyncio.sleep(0.1)
-		return await self._element_is_checked(element) == checked
+		return await cdp.set_checkbox_state(elements[0], checked)
 
 	async def _element_is_visible(self, element) -> bool:
 		"""Check if an element is visible."""
@@ -812,14 +807,20 @@ class SemanticWorkflowExecutor:
 		return {{ success: false, error: error.message }};
 	}}
 }}"""
-						click_result = await page.evaluate(click_js)
+						# evaluate returns a JSON string; decode before inspecting -
+						# treating it as a dict raised AttributeError AFTER the click
+						# already fired in the page (click-then-report-failure trap)
+						click_result = await cdp.evaluate(page, click_js)
 
-						if click_result and click_result.get('success'):
+						if isinstance(click_result, dict) and click_result.get('success'):
 							msg = f'🖱️ Clicked element using XPath: {xpath_or_selector}'
 							logger.info(msg)
 							return ActionResult(extracted_content=msg, include_in_memory=True)
 						else:
-							raise Exception(f'Failed to click element: {click_result.get("error", "Unknown error")}')
+							error_detail = (
+								click_result.get('error', 'Unknown error') if isinstance(click_result, dict) else click_result
+							)
+							raise Exception(f'Failed to click element: {error_detail}')
 					else:
 						raise Exception(f'Unsupported strategy type: {strategy_used.get("type")}')
 

--- a/workflows/workflow_use/workflow/semantic_executor.py
+++ b/workflows/workflow_use/workflow/semantic_executor.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 from browser_use.agent.views import ActionResult
 from browser_use.llm.base import BaseChatModel
 
+from workflow_use.compat import cdp
 from workflow_use.schema.views import (
 	ClickStep,
 	ExtractStep,
@@ -133,6 +134,23 @@ class SemanticWorkflowExecutor:
 		"""Check if an element is checked (for radio/checkbox)."""
 		checked = await self._element_get_property(element, 'checked')
 		return bool(checked)
+
+	async def _set_checked_by_selector(self, selector: str, checked: bool = True) -> bool:
+		"""Set a radio/checkbox checked state via CDP (Playwright check/uncheck equivalent).
+
+		Clicks the first element matching *selector* when its checked state differs
+		from the desired one. Returns True when the element ends in the desired state.
+		"""
+		elements = await self._get_elements_by_selector(selector)
+		if not elements:
+			logger.debug(f'_set_checked_by_selector: no element for {selector}')
+			return False
+		element = elements[0]
+		if await self._element_is_checked(element) == checked:
+			return True
+		await element.click()
+		await asyncio.sleep(0.1)
+		return await self._element_is_checked(element) == checked
 
 	async def _element_is_visible(self, element) -> bool:
 		"""Check if an element is visible."""
@@ -562,22 +580,25 @@ class SemanticWorkflowExecutor:
 				if element_count == 0:
 					continue
 
-				# Check if it's visible
-				await page.wait_for_selector(selector, timeout=2000, state='visible')
+				# Check if it's visible (wait_for_selector doesn't exist on CDP)
+				if await cdp.wait_for_element(page, selector, timeout_ms=2000) is None:
+					continue
 
 				# Check if this selector resolves to multiple elements (strict mode violation)
 				if element_count > 1:
 					logger.warning(f'Selector {selector} matches {element_count} elements, trying to make it more specific')
 
 					# Try to make it more specific for form elements
-					specific_selectors = [f"{selector}:not([type='hidden'])", f'{selector}:visible', f'{selector}:first-of-type']
+					# (:visible is a Playwright-only pseudo-class - invalid CSS here)
+					specific_selectors = [f"{selector}:not([type='hidden'])", f'{selector}:first-of-type']
 
 					for specific_selector in specific_selectors:
 						try:
 							specific_elements = await self._get_elements_by_selector(specific_selector)
 							specific_count = len(specific_elements)
 							if specific_count == 1:
-								await page.wait_for_selector(specific_selector, timeout=1000, state='visible')
+								if await cdp.wait_for_element(page, specific_selector, timeout_ms=1000) is None:
+									continue
 								logger.info(f'Found specific element using selector: {specific_selector}')
 								return specific_selector
 						except Exception:
@@ -720,10 +741,7 @@ class SemanticWorkflowExecutor:
 		await asyncio.sleep(3)
 
 		# Wait for common form elements to be present (indicates page is ready)
-		try:
-			# Wait for any input, button, or form element to be present
-			await page.wait_for_selector('input, button, form, textarea, select', timeout=10000)
-		except Exception:
+		if await cdp.wait_for_element(page, 'input, button, form, textarea, select', timeout_ms=10000, state='attached') is None:
 			logger.warning('No form elements found after navigation, continuing anyway')
 
 		# Refresh semantic mapping after navigation
@@ -1089,8 +1107,9 @@ class SemanticWorkflowExecutor:
 							logger.info(f'Successfully clicked ARIA radio button: {selector}')
 							return True
 						elif tag_name == 'input':
-							# Traditional input, use check() method
-							await page.check(selector)
+							# Traditional input: set checked state via CDP click
+							if not await self._set_checked_by_selector(selector):
+								raise Exception(f'Could not check {selector}')
 							logger.info(f'Successfully checked {element_info["element_type"]}: {selector}')
 							return True
 						else:
@@ -1122,7 +1141,8 @@ class SemanticWorkflowExecutor:
 										await element.click()
 										return True
 									else:
-										await page.check(input_selector)
+										if not await self._set_checked_by_selector(input_selector):
+											raise Exception(f'Could not check {input_selector}')
 										logger.info(
 											f'Successfully checked {element_info["element_type"]} input inside container: {input_selector}'
 										)
@@ -1336,15 +1356,17 @@ class SemanticWorkflowExecutor:
 									specific_elements = await self._get_elements_by_selector(specific_selector)
 									count = len(specific_elements)
 									if count == 1:
-										await page.check(specific_selector)
+										if not await self._set_checked_by_selector(specific_selector):
+											raise Exception(f'Could not check {specific_selector}')
 										logger.info(f'Successfully checked using specific selector: {specific_selector}')
 										return True
 								except Exception as e:
 									logger.debug(f'Specific check failed for {specific_selector}: {e}')
 									continue
 					else:
-						# Use the provided selector with .check()
-						await page.check(selector)
+						# Use the provided selector, setting checked state via CDP click
+						if not await self._set_checked_by_selector(selector):
+							raise Exception(f'Could not check {selector}')
 						logger.info(f'Successfully checked: {selector}')
 						return True
 
@@ -1368,8 +1390,9 @@ class SemanticWorkflowExecutor:
 								logger.info(f'Clicked specific radio/checkbox by value: {target_text}')
 								return True
 
-						# Fall back to first match - use page.check with selector since we can't .check() on element
-						await page.check(selector)
+						# Fall back to the first matching element
+						if not await self._set_checked_by_selector(selector):
+							raise Exception(f'Could not check {selector}')
 						logger.warning(f'Selected first radio button (multiple found): {selector}')
 						return True
 				except Exception as e:
@@ -1567,16 +1590,17 @@ class SemanticWorkflowExecutor:
 						radio_elements = await self._get_elements_by_selector(radio_selector)
 						count = len(radio_elements)
 						if count == 1:
-							await page.check(radio_selector)
+							if not await self._set_checked_by_selector(radio_selector):
+								raise Exception(f'Could not check {radio_selector}')
 							logger.info(f'Successfully selected radio button: {radio_selector}')
 							return True
 						elif count > 1:
 							# Multiple radio buttons with same value, try to narrow down by name or context
 							if target_text:
 								# Try to find by label association
+								# (:has-text() is Playwright-only and invalid CSS here)
 								contextual_selectors = [
 									f'input[type="radio"][value="{value.lower()}"][name*="{target_text.lower()}"]',
-									f'label:has-text("{target_text}") input[type="radio"][value="{value.lower()}"]',
 								]
 
 								for ctx_selector in contextual_selectors:
@@ -1584,15 +1608,17 @@ class SemanticWorkflowExecutor:
 										ctx_elements = await self._get_elements_by_selector(ctx_selector)
 										ctx_count = len(ctx_elements)
 										if ctx_count == 1:
-											await page.check(ctx_selector)
+											if not await self._set_checked_by_selector(ctx_selector):
+												raise Exception(f'Could not check {ctx_selector}')
 											logger.info(f'Selected radio button with context: {ctx_selector}')
 											return True
 									except Exception as e:
 										logger.debug(f'Contextual radio selection failed: {e}')
 										continue
 
-							# Fall back to first match - use page.check with selector since we can't .check() on element
-							await page.check(radio_selector)
+							# Fall back to the first matching radio button
+							if not await self._set_checked_by_selector(radio_selector):
+								raise Exception(f'Could not check {radio_selector}')
 							logger.warning(f'Selected first radio button (multiple found): {radio_selector}')
 							return True
 					except Exception as e:
@@ -1614,13 +1640,10 @@ class SemanticWorkflowExecutor:
 						raise Exception(f'Checkbox element not found: {selector}')
 					is_currently_checked = await self._element_is_checked(checkbox_elements[0])
 
-					if should_check and not is_currently_checked:
-						await page.check(selector)
-						logger.info(f'Checked checkbox: {target_text}')
-						return True
-					elif not should_check and is_currently_checked:
-						await page.uncheck(selector)
-						logger.info(f'Unchecked checkbox: {target_text}')
+					if is_currently_checked != should_check:
+						if not await self._set_checked_by_selector(selector, checked=should_check):
+							raise Exception(f'Could not set checkbox state for {selector}')
+						logger.info(f'{"Checked" if should_check else "Unchecked"} checkbox: {target_text}')
 						return True
 					else:
 						logger.info(f'Checkbox already in desired state: {target_text}')
@@ -1706,8 +1729,11 @@ class SemanticWorkflowExecutor:
 			if not elements:
 				raise Exception(f'Element not found with selector: {selector_to_use}')
 			element = elements[0]
-			# select_option takes values (text or value of the option)
-			await element.select_option(step.selectedText)
+			# Match by visible label text (Element.select_option only matches option
+			# VALUES - option label text is invisible to it, so it silently selects
+			# nothing when values differ from labels)
+			if not await cdp.select_option_by_text(element, step.selectedText):
+				raise Exception(f'No option with visible text "{step.selectedText}" in {selector_to_use}')
 
 			msg = f"🔽 Selected '{step.selectedText}' in: {target_identifier or step.description or selector_to_use}"
 			logger.info(msg)
@@ -2054,8 +2080,8 @@ class SemanticWorkflowExecutor:
 		screenshot_path = None
 		try:
 			page = await self.browser.get_current_page()
-			current_url = page.url if page else None
-			page_title = await page.title() if page else None
+			current_url = await page.get_url() if page else None
+			page_title = await page.get_title() if page else None
 
 			# Capture error screenshot for debugging
 			try:
@@ -2073,8 +2099,8 @@ class SemanticWorkflowExecutor:
 				screenshot_filename = f'error_{timestamp}_step{self.current_step_index}_{step_desc}.png'
 				screenshot_path = str(screenshot_dir / screenshot_filename)
 
-				# Capture screenshot
-				await page.screenshot(path=screenshot_path)
+				# Capture screenshot (CDP returns base64; decode and write ourselves)
+				await cdp.screenshot_to_file(page, screenshot_path)
 				logger.info(f'📸 Error screenshot saved: {screenshot_path}')
 
 			except Exception as screenshot_error:
@@ -2254,8 +2280,7 @@ class SemanticWorkflowExecutor:
 			try:
 				page = await self.browser.get_current_page()
 				direct_selector = await self._try_direct_selector(target_text)
-				if direct_selector:
-					await page.wait_for_selector(direct_selector, timeout=2000, state='visible')
+				if direct_selector and await cdp.wait_for_element(page, direct_selector, timeout_ms=2000) is not None:
 					logger.info(
 						f"Verification: Found next step element by direct selector '{target_text}' - navigation successful"
 					)
@@ -2659,8 +2684,12 @@ EXTRACTED INFORMATION:"""
 			# Call LLM for extraction
 			logger.info('Sending extraction request to LLM...')
 			try:
-				llm_response = await self.page_extraction_llm.ainvoke(formatted_prompt)
-				extracted_content = llm_response.content if hasattr(llm_response, 'content') else str(llm_response)
+				# BaseChatModel.ainvoke takes a message list and returns ChatInvokeCompletion
+				# (whose field is .completion - there is no .content)
+				from browser_use.llm import UserMessage
+
+				llm_response = await self.page_extraction_llm.ainvoke([UserMessage(content=formatted_prompt)])
+				extracted_content = llm_response.completion
 
 				# Create structured extracted data
 				extracted_data = {
@@ -2769,84 +2798,96 @@ EXTRACTED INFORMATION:"""
 		page = await self.browser.get_current_page()
 
 		try:
-			# Step 1: Find the container
-			container_element = None
+			# One page round-trip: resolve the container (by selector or by text) and
+			# scan its interactive descendants for the target text.
+			# (query_selector_all / text_content do not exist on the CDP surface.)
+			find_js = """(containerSelector, containerText, targetText) => {
+				let container = null;
+				if (containerSelector) {
+					try { container = document.querySelector(containerSelector); } catch (e) {}
+				} else if (containerText) {
+					const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+					let node;
+					while ((node = walker.nextNode())) {
+						if (node.textContent && node.textContent.includes(containerText)) {
+							container = node.parentElement && node.parentElement.closest('tr, section, form');
+							if (container) break;
+						}
+					}
+				}
+				if (!container) return { found: false, reason: 'container' };
+				const wanted = targetText.toLowerCase();
+				const candidates = container.querySelectorAll("button, input, select, a, [role='button']");
+				for (const el of candidates) {
+					const text = (el.textContent || el.value || '').trim();
+					if (text && text.toLowerCase().includes(wanted)) {
+						return {
+							found: true,
+							text: text,
+							tag: el.tagName.toLowerCase(),
+							id: el.id || '',
+							cls: el.className && typeof el.className === 'string' ? el.className : '',
+							containerTag: container.tagName.toLowerCase(),
+							containerId: container.id || '',
+							containerCls: container.className && typeof container.className === 'string' ? container.className : '',
+						};
+					}
+				}
+				return { found: false, reason: 'target' };
+			}"""
 
-			if container_selector:
-				# Use provided selector
-				container_elements = await page.query_selector_all(container_selector)
-				if container_elements:
-					container_element = container_elements[0]
-					logger.info(f'Found container using selector: {container_selector}')
+			result = await cdp.evaluate(page, find_js, container_selector or '', container_text or '', target_text)
 
-			elif container_text:
-				# Find container by text content using XPath
-				xpath_query = f"xpath=//*[contains(text(), '{container_text}')]/ancestor-or-self::tr | //*[contains(text(), '{container_text}')]/ancestor-or-self::section | //*[contains(text(), '{container_text}')]/ancestor-or-self::form"
-				container_element = await page.query_selector(xpath_query)
-				if container_element:
-					logger.info(f'Found container containing text: {container_text}')
-
-			if not container_element:
-				logger.warning(f'Could not find container for {target_text}')
+			if not isinstance(result, dict) or not result.get('found'):
+				reason = result.get('reason') if isinstance(result, dict) else 'error'
+				if reason == 'container':
+					logger.warning(f'Could not find container for {target_text}')
+				else:
+					logger.warning(f"Could not find '{target_text}' within the container")
 				return None
 
-			# Step 2: Find the target element within the container
-			target_elements = await container_element.query_selector_all("button, input, select, a, [role='button']")
+			element_tag = result.get('tag') or 'unknown'
+			element_id = result.get('id') or ''
+			element_class = result.get('cls') or ''
 
-			for element in target_elements:
-				element_text = await element.text_content()
-				if element_text and target_text.lower() in element_text.lower().strip():
-					# Generate a dynamic selector for this element
-					element_id = await element.get_attribute('id')
-					element_class = await element.get_attribute('class')
-					element_tag_upper = await self._element_get_property(element, 'tagName')
-					element_tag = element_tag_upper.lower() if element_tag_upper else 'unknown'
+			# Build selector
+			if element_id:
+				dynamic_selector = f'#{element_id}'
+			elif element_class:
+				classes = element_class.split()[0] if element_class.split() else ''
+				dynamic_selector = f'{element_tag}.{classes}' if classes else element_tag
+			else:
+				dynamic_selector = element_tag
 
-					# Build selector
-					if element_id:
-						dynamic_selector = f'#{element_id}'
-					elif element_class:
-						classes = element_class.split()[0] if element_class.split() else ''
-						dynamic_selector = f'{element_tag}.{classes}' if classes else element_tag
-					else:
-						dynamic_selector = element_tag
+			# Make it specific to the container
+			if container_selector:
+				final_selector = f'{container_selector} {dynamic_selector}'
+			else:
+				container_tag = result.get('containerTag') or 'unknown'
+				container_id = result.get('containerId') or ''
+				container_class = result.get('containerCls') or ''
+				if container_id:
+					container_sel = f'#{container_id}'
+				elif container_class:
+					first_class = container_class.split()[0] if container_class.split() else ''
+					container_sel = f'{container_tag}.{first_class}' if first_class else container_tag
+				else:
+					container_sel = container_tag
+				final_selector = f'{container_sel} {dynamic_selector}'
 
-					# Make it specific to the container
-					if container_selector:
-						final_selector = f'{container_selector} {dynamic_selector}'
-					else:
-						# Generate container selector on the fly
-						container_id = await container_element.get_attribute('id')
-						container_class = await container_element.get_attribute('class')
-						container_tag_upper = await self._element_get_property(container_element, 'tagName')
-						container_tag = container_tag_upper.lower() if container_tag_upper else 'unknown'
+			logger.info(f"Found '{target_text}' in container: {final_selector}")
 
-						if container_id:
-							container_sel = f'#{container_id}'
-						elif container_class:
-							first_class = container_class.split()[0] if container_class.split() else ''
-							container_sel = f'{container_tag}.{first_class}' if first_class else container_tag
-						else:
-							container_sel = container_tag
-
-						final_selector = f'{container_sel} {dynamic_selector}'
-
-					logger.info(f"Found '{target_text}' in container: {final_selector}")
-
-					# Return element info in the same format as semantic mapping
-					return {
-						'selectors': final_selector,
-						'hierarchical_selector': final_selector,
-						'fallback_selector': dynamic_selector,
-						'text_xpath': f"//*[contains(text(), '{target_text}')]",
-						'element_type': 'button',
-						'original_text': element_text.strip(),
-						'class': element_class or '',
-						'id': element_id or '',
-					}
-
-			logger.warning(f"Could not find '{target_text}' within the container")
-			return None
+			# Return element info in the same format as semantic mapping
+			return {
+				'selectors': final_selector,
+				'hierarchical_selector': final_selector,
+				'fallback_selector': dynamic_selector,
+				'text_xpath': f"//*[contains(text(), '{target_text}')]",
+				'element_type': 'button',
+				'original_text': str(result.get('text') or '').strip(),
+				'class': element_class,
+				'id': element_id,
+			}
 
 		except Exception as e:
 			logger.error(f'Error in find_element_in_container: {e}')
@@ -3098,18 +3139,25 @@ EXTRACTED INFORMATION:"""
 				logger.warning(f'Trigger element not found: {selector}')
 				return False
 
-			# Wait for expected content to appear
-			try:
-				# Try multiple strategies to detect content loading
-				await page.wait_for_selector(f':has-text("{expected_content}")', timeout=timeout)
-				logger.info(f'Dynamic content loaded: {expected_content}')
-				return True
+			# Wait for expected content to appear by polling the page text
+			# (:has-text() is Playwright-only; poll body text via evaluate instead)
+			deadline = asyncio.get_event_loop().time() + timeout / 1000
+			while asyncio.get_event_loop().time() < deadline:
+				try:
+					found = await cdp.evaluate(
+						page,
+						'(needle) => document.body && document.body.innerText.includes(needle)',
+						expected_content,
+					)
+					if found is True:
+						logger.info(f'Dynamic content loaded: {expected_content}')
+						return True
+				except Exception:
+					pass
+				await asyncio.sleep(0.2)
 
-			except Exception:
-				# Wait for dynamic content to load
-				await asyncio.sleep(timeout / 1000)  # Convert ms to seconds
-				logger.info('Dynamic content loading completed (timeout-based)')
-				return True
+			logger.info('Dynamic content loading completed (timeout-based)')
+			return True
 
 		except Exception as e:
 			logger.error(f'Error handling dynamic content loading: {e}')

--- a/workflows/workflow_use/workflow/service.py
+++ b/workflows/workflow_use/workflow/service.py
@@ -15,6 +15,7 @@ from browser_use.llm.base import BaseChatModel
 from browser_use.tools.views import NoParamsAction
 from pydantic import BaseModel, Field, create_model
 
+from workflow_use.compat import cdp
 from workflow_use.controller.service import WorkflowController
 from workflow_use.controller.utils import get_best_element_handle
 from workflow_use.schema.views import (
@@ -233,12 +234,13 @@ class Workflow:
 			params = NoParamsAction()  # type: ignore
 
 		ActionModel = self.controller.registry.create_action_model(include_actions=[action_name])
-		# Pass the params dictionary directly
-		# For empty actions, ActionModel itself IS the action (EmptyActionModel), so don't wrap in dict
-		if action_name in empty_actions:
-			action_model = ActionModel()
-		else:
-			action_model = ActionModel(**{action_name: params})
+		if not ActionModel.model_fields:
+			# include_actions found nothing: a bare ActionModel() would dump to {} and
+			# Tools.act would silently no-op while reporting success.
+			raise RuntimeError(f"Action '{action_name}' is not registered in the workflow controller")
+		# The action model always wraps params under the action name; NoParamsAction
+		# instances included (an EMPTY ActionModel() would silently no-op).
+		action_model = ActionModel(**{action_name: params})
 
 		try:
 			result = await self.controller.act(action_model, self.browser, page_extraction_llm=self.page_extraction_llm)
@@ -250,12 +252,14 @@ class Workflow:
 		if action_name in actions_requiring_wait:
 			try:
 				page = await self.browser.get_current_page()
-				# Wait for network to be idle (no more than 2 connections for at least 500ms)
-				await page.wait_for_load_state('networkidle', timeout=10000)
-				logger.info(f'Page stabilized after {action_name} action')
+				# Wait for the document to finish loading and settle briefly
+				if await cdp.wait_for_load_state(page, 'networkidle', timeout_ms=10000):
+					logger.info(f'Page stabilized after {action_name} action')
+				else:
+					logger.warning(f'Timeout waiting for page to stabilize after {action_name}')
 			except Exception as e:
-				# Don't fail if wait times out, just log and continue
-				logger.warning(f'Timeout waiting for page to stabilize after {action_name}: {e}')
+				# Don't fail if the wait itself errors, just log and continue
+				logger.warning(f'Error waiting for page to stabilize after {action_name}: {e}')
 
 		# Helper function to truncate long selectors in logs
 		def truncate_selector(selector: str) -> str:
@@ -839,9 +843,9 @@ Extracted Information:"""
 			filename = f'step_{step_index + 1:02d}_{prefix_str}{clean_description}_{timestamp}.png'
 			screenshot_path = self.debug_log_folder / filename
 
-			# Capture screenshot
+			# Capture screenshot (CDP screenshot returns base64; write it ourselves)
 			page = await self.browser.get_current_page()
-			await page.screenshot(path=str(screenshot_path), full_page=True)
+			await cdp.screenshot_to_file(page, str(screenshot_path))
 
 			logger.info(f'📸 Debug screenshot saved: {screenshot_path}')
 

--- a/workflows/workflow_use/workflow/validation_utils.py
+++ b/workflows/workflow_use/workflow/validation_utils.py
@@ -5,7 +5,12 @@ This module provides common functionality for identifying form validation errors
 and other error messages displayed on web pages.
 """
 
+import logging
 from typing import List, Optional, Tuple
+
+from workflow_use.compat import cdp
+
+logger = logging.getLogger(__name__)
 
 # Common CSS selectors for error messages across different frameworks and patterns
 VALIDATION_ERROR_SELECTORS = [
@@ -22,6 +27,59 @@ VALIDATION_ERROR_SELECTORS = [
 	'.help-block.error',
 ]
 
+# Strings that indicate framework/browser internals rather than user-facing errors
+_INTERNAL_PATTERNS = [
+	'document.getElementById',
+	'function addPageBinding',
+	'serializeAsCallArgument',
+	'__next_f',
+	'globalThis',
+	'self.__next_f',
+]
+
+# One page round-trip: collect the visible text of every matching error element.
+_COLLECT_ERRORS_JS = """(selectors) => {
+	const out = [];
+	for (const selector of selectors) {
+		let nodes = [];
+		try { nodes = document.querySelectorAll(selector); } catch (e) { continue; }
+		for (const node of nodes) {
+			const rect = node.getBoundingClientRect();
+			const style = getComputedStyle(node);
+			const visible = rect.width > 0 && rect.height > 0 && style.visibility !== 'hidden' && style.display !== 'none';
+			if (!visible) continue;
+			const text = (node.textContent || '').trim();
+			if (text) out.push(text);
+		}
+	}
+	return out;
+}"""
+
+
+def _clean_error_texts(raw_texts: List[str]) -> List[str]:
+	"""Filter out framework internals / oversized blobs, dedupe preserving order."""
+	errors: List[str] = []
+	for text in raw_texts:
+		clean_text = text.strip()
+		if not clean_text:
+			continue
+		# Skip if it looks like browser internal code
+		if any(pattern in clean_text for pattern in _INTERNAL_PATTERNS):
+			continue
+		# Skip very long messages (likely technical content, not user-facing errors)
+		if len(clean_text) > 200:
+			continue
+		if clean_text not in errors:
+			errors.append(clean_text)
+	return errors
+
+
+async def _collect_visible_error_texts(page) -> List[str]:
+	result = await cdp.evaluate(page, _COLLECT_ERRORS_JS, VALIDATION_ERROR_SELECTORS)
+	if not isinstance(result, list):
+		return []
+	return _clean_error_texts([str(item) for item in result])
+
 
 async def detect_validation_errors(page) -> Tuple[bool, Optional[str]]:
 	"""
@@ -31,7 +89,7 @@ async def detect_validation_errors(page) -> Tuple[bool, Optional[str]]:
 	that are commonly used across different web frameworks (Bootstrap, Tailwind, etc.).
 
 	Args:
-	    page: Playwright Page object
+	    page: browser-use actor Page object
 
 	Returns:
 	    Tuple of (has_errors: bool, error_message: Optional[str])
@@ -44,46 +102,13 @@ async def detect_validation_errors(page) -> Tuple[bool, Optional[str]]:
 	        print(f"Validation error: {error_text}")
 	"""
 	try:
-		for selector in VALIDATION_ERROR_SELECTORS:
-			try:
-				elements = await page.query_selector_all(selector)
-				if elements:
-					# Check if any are visible
-					for elem in elements:
-						is_visible = await elem.is_visible()
-						if is_visible:
-							text = await elem.text_content()
-							if text and text.strip():
-								# Filter out browser internal scripts and technical content
-								clean_text = text.strip()
-
-								# Skip if it looks like browser internal code
-								if any(
-									pattern in clean_text
-									for pattern in [
-										'document.getElementById',
-										'function addPageBinding',
-										'serializeAsCallArgument',
-										'__next_f',
-										'globalThis',
-										'self.__next_f',
-									]
-								):
-									continue
-
-								# Skip very long messages (likely technical content, not user-facing errors)
-								if len(clean_text) > 200:
-									continue
-
-								return True, clean_text
-			except Exception:
-				# Ignore errors for individual selectors, try next one
-				continue
-
+		errors = await _collect_visible_error_texts(page)
+		if errors:
+			return True, errors[0]
 		return False, None
-
 	except Exception as e:
 		# If we can't check for errors, assume no errors to avoid blocking
+		logger.debug(f'Validation-error detection failed: {e}')
 		return False, None
 
 
@@ -92,7 +117,7 @@ async def get_all_validation_errors(page) -> List[str]:
 	Get all validation error messages visible on the page.
 
 	Args:
-	    page: Playwright Page object
+	    page: browser-use actor Page object
 
 	Returns:
 	    List of error message strings (may be empty if no errors found)
@@ -102,43 +127,8 @@ async def get_all_validation_errors(page) -> List[str]:
 	    for error in errors:
 	        print(f"Error: {error}")
 	"""
-	errors = []
-
 	try:
-		for selector in VALIDATION_ERROR_SELECTORS:
-			try:
-				elements = await page.query_selector_all(selector)
-				if elements:
-					for elem in elements:
-						is_visible = await elem.is_visible()
-						if is_visible:
-							text = await elem.text_content()
-							if text and text.strip():
-								clean_text = text.strip()
-
-								# Skip browser internal code
-								if any(
-									pattern in clean_text
-									for pattern in [
-										'document.getElementById',
-										'function addPageBinding',
-										'serializeAsCallArgument',
-										'__next_f',
-										'globalThis',
-										'self.__next_f',
-									]
-								):
-									continue
-
-								# Skip very long messages
-								if len(clean_text) > 200:
-									continue
-
-								if clean_text not in errors:  # Avoid duplicates
-									errors.append(clean_text)
-			except Exception:
-				continue
-	except Exception:
-		pass
-
-	return errors
+		return await _collect_visible_error_texts(page)
+	except Exception as e:
+		logger.debug(f'Validation-error collection failed: {e}')
+		return []


### PR DESCRIPTION
## Problem

The replay engine is written against **Playwright's API**, but runs on **browser-use 0.13's CDP actor surface**, which has none of it. Verified with the pinned version (`browser-use==0.13.4`):

| Called by the engine | On CDP actor Page/Element |
|---|---|
| `page.locator` / `locator.wait_for` | ❌ doesn't exist |
| `page.wait_for_selector` / `wait_for_load_state` | ❌ doesn't exist |
| `page.check` / `page.uncheck` | ❌ doesn't exist |
| `page.query_selector_all` / `el.is_visible()` / `el.text_content()` | ❌ doesn't exist |
| `locator.click(force=True)` | ❌ no `force=` kwarg |
| `locator.select_option(label=...)` | ❌ `values` only — option label text is invisible to it |
| `locator.press` | ❌ Element has no `press` |
| `page.screenshot(path=...)` | ❌ returns base64, no `path=` |
| `evaluate` treated as returning dict/bool | ❌ always returns a **string** (JSON-stringified) |

Because nearly every call site wraps these in broad `except` blocks, the failures are **silent**: `get_best_element_handle` exhausts all fallbacks and raises for every selector, so **any recorded workflow with a `cssSelector` step fails on its first element interaction**. Radio/checkbox steps only 'succeed' when the state already matches; form-validation detection always returns 'no errors' (rejected submits are reported SUCCESS); XPath fallback never fires; the multi-strategy finder reads `node.text`/`node.aria_label` etc. that don't exist on the slotted `EnhancedDOMTreeNode`, so no semantic strategy can ever match.

## Fix (reviewable commit-by-commit)

1. **`test(contract)`** — an import-time API-contract test (`workflows/tests/test_browser_use_contract.py`, no browser launch):
   - asserts every Page/Element/Browser attribute the engine relies on exists with a compatible signature (fails at CI time on a breaking browser-use upgrade, instead of silently at replay time)
   - a static scan asserting no Playwright-only API call exists outside the compat layer — it failed with **35 real call sites** before the port and is green after; it also prevents this bug class from regressing
2. **`fix(replay)` deterministic path** — new `workflow_use/compat/cdp.py` (single module that knows the Playwright↔CDP differences: polling `wait_for_element`, visibility via geometry+computed style, XPath resolution via a temporary marker attribute, JSON-decoding of `evaluate` string returns, readyState-based load waits, base64 screenshot-to-file, checkbox state setter, select-by-visible-text with proper `input`/`change` events) + ports `controller/utils.py`, `controller/service.py`, `workflow/service.py`. Also:
   - `DISABLED_DEFAULT_ACTIONS` listed pre-0.2 action names, so only 4 of 27 matched and 16 agent-only builtins stayed registered while custom `click`/`input`/`scroll` silently overwrote builtins — replaced with excluding all builtins by their real names + explicit registrations
   - `go_back`/`go_forward` steps built an **empty** `ActionModel()`, which `Tools.act` no-ops while reporting success — now real CDP navigations
   - dropped Playwright-only `:has-text()`/`:visible` selectors (invalid CSS that throws in `querySelectorAll`)
3. **`fix(replay)` semantic executor / validation / element finder** — same treatment for `semantic_executor.py` (11 `page.check` sites, 5 `wait_for_selector` sites, select-by-visible-text, AI extraction called `ainvoke(str)` and read `.content` while the API takes a message list and exposes `.completion`), `validation_utils.py` (rewritten as one page-evaluate pass), and `element_finder.py` (reads the real node sources: `attributes` dict, `ax_node`, `get_all_children_text()`).

## Verification

```bash
cd workflows && uv run pytest tests/test_browser_use_contract.py -q   # 14 passed
```

Related: #165 (recording-side findings), #166 (recording pipeline fixes — independent; both PRs apply cleanly in either order aside from trivial context overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the replay engine from Playwright APIs to the `browser-use` 0.13 CDP actor surface, restoring deterministic replay. Adds a CDP compat layer and contract tests so API breaks fail fast instead of silently at runtime.

- **Bug Fixes**
  - Replaced Playwright-only calls with CDP equivalents: selector waits, visibility checks, XPath resolution, evaluate return decoding, load-state waits, screenshots, key press, checkbox/radio handling, and select-by-visible-text.
  - Controller now excludes all built-in agent actions and registers deterministic actions explicitly; implements real back/forward navigation (fixes prior no-op success).
  - Element finder reads real `EnhancedDOMTreeNode` sources (attributes/AX/text, including nested `{'attributes': {...}}`), uses CDP-safe text/XPath strategies with per-lookup marker tokens, and a page-side text finder that scans rendered `innerText` and polls until timeout; removed `:has-text()`/`:visible`.
  - Validation reworked to collect visible error texts in one pass; prevents false “success” after rejected submits.
  - Error reporting uses `get_url`/`get_title` and writes base64 screenshots; XPath click path now decodes evaluate JSON before inspecting; checkbox state handling is centralized via `cdp.set_checkbox_state`.

- **New Features**
  - New `workflow_use/compat/cdp.py` shims: `wait_for_element`, visibility via geometry+style, XPath resolution with tokenized markers, readyState-based load waits, base64 screenshot-to-file, checkbox state setter, select-by-visible-text, and focused key press.
  - Import-time contract tests assert `Page`/`Element`/`Browser` API surface and statically block Playwright-only calls to guard `browser-use` upgrades.
  - Dev setup: add `pytest` for the contract test; remove `pytest-asyncio` and pytest config. Run the gate with: `uv run pytest tests/test_browser_use_contract.py`.

<sup>Written for commit c25a7efef857c5fc0b7d219f4bb119e8c04475f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/workflow-use/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

