### PR TITLE
Fix generation and self-healing bugs found in hands-on testing

### DIFF
--- a/workflows/workflow_use/healing/prompts/workflow_creation_prompt.md
+++ b/workflows/workflow_use/healing/prompts/workflow_creation_prompt.md
@@ -23,10 +23,10 @@ You are a master at building re-executable workflows from browser automation ste
    - Use `{{variable}}` syntax (one pair of curly braces) in `target_text` for dynamic values
    - Example: `{{"type": "click", "target_text": "{{repo_name}}"}}`
 
-4. **Variables MUST use {variable} syntax (one pair of curly braces)**
+4. **Variables MUST use {{variable}} syntax (one pair of curly braces)**
    - ✅ CORRECT: `"value": "{{email}}"` or `"target_text": "{{repo_name}}"`
    - ❌ WRONG: `"value": "{{{{email}}}}"` or `"value": "email"`
-   - Python's str.format() substitutes {variable} with actual values at runtime
+   - Python's str.format() substitutes {{variable}} with actual values at runtime
 
 5. **Prefer direct navigation over search engines!**
    - If task involves "search GitHub" → Navigate directly to https://github.com

--- a/workflows/workflow_use/healing/service.py
+++ b/workflows/workflow_use/healing/service.py
@@ -244,7 +244,7 @@ class HealingService:
 			if screenshot:
 				# Assuming screenshot is a base64 encoded string.
 				# Adjust mime type if necessary (e.g., image/png)
-				image_block: Dict[str, Any] = {'type': 'image_url', 'image_url': {'url': f'data:image/jpeg;base64,{screenshot}'}}
+				image_block: Dict[str, Any] = {'type': 'image_url', 'image_url': {'url': f'data:image/png;base64,{screenshot}'}}
 				content_blocks.append(image_block)
 
 			messages.append(UserMessage(content=content_blocks))

--- a/workflows/workflow_use/workflow/service.py
+++ b/workflows/workflow_use/workflow/service.py
@@ -19,13 +19,23 @@ from workflow_use.controller.service import WorkflowController
 from workflow_use.controller.utils import get_best_element_handle
 from workflow_use.schema.views import (
 	AgenticWorkflowStep,
+	ClickStep,
 	DeterministicWorkflowStep,
+	InputStep,
+	KeyPressStep,
+	NavigationStep,
+	ScrollStep,
+	SelectChangeStep,
 	WorkflowDefinitionSchema,
 	WorkflowInputSchemaDefinition,
 	WorkflowStep,
 )
 from workflow_use.workflow.element_finder import ElementFinder
-from workflow_use.workflow.prompts import AGENT_STEP_SYSTEM_PROMPT, STRUCTURED_OUTPUT_PROMPT
+from workflow_use.workflow.prompts import (
+	AGENT_STEP_SYSTEM_PROMPT,
+	STRUCTURED_OUTPUT_PROMPT,
+	WORKFLOW_FALLBACK_PROMPT_TEMPLATE,
+)
 from workflow_use.workflow.step_agent.controller import WorkflowStepAgentController
 from workflow_use.workflow.views import WorkflowRunOutput
 
@@ -418,79 +428,75 @@ Extracted Information:"""
 			include_in_memory=True,
 		)
 
-	# async def _fallback_to_agent(
-	# 	self,
-	# 	step_resolved: WorkflowStep,
-	# 	step_index: int,
-	# 	error: Exception | str | None = None,
-	# ) -> AgentHistoryList:
-	# 	"""Handle step failure by delegating to an agent."""
+	async def _fallback_to_agent(
+		self,
+		step_resolved: WorkflowStep,
+		step_index: int,
+		error: Exception | str | None = None,
+	) -> AgentHistoryList:
+		"""Handle step failure by delegating to an agent."""
 
-	# 	# print('Workflow steps:', step_resolved)
-	# 	# Extract details from the failed step dictionary
-	# 	failed_action_name = step_resolved.type
-	# 	failed_params = step_resolved.model_dump()
-	# 	step_description = step_resolved.description or 'No description provided'
-	# 	error_msg = str(error) if error else 'Unknown error'
-	# 	total_steps = len(self.steps)
-	# 	fail_details = (
-	# 		f"step={step_index + 1}/{total_steps}, action='{failed_action_name}', "
-	# 		f"description='{step_description}', params={str(failed_params)}, error='{error_msg}'"
-	# 	)
+		# Extract details from the failed step dictionary
+		failed_action_name = step_resolved.type
+		failed_params = step_resolved.model_dump()
+		step_description = step_resolved.description or 'No description provided'
+		error_msg = str(error) if error else 'Unknown error'
+		total_steps = len(self.schema.steps)
+		fail_details = (
+			f"step={step_index + 1}/{total_steps}, action='{failed_action_name}', "
+			f"description='{step_description}', params={str(failed_params)}, error='{error_msg}'"
+		)
 
-	# 	# Determine the failed_value based on step type and attributes
-	# 	failed_value = None
-	# 	description_prefix = f'Purpose: {step_description}. ' if step_description else ''
+		# Determine the failed_value based on step type and attributes
+		failed_value = None
+		description_prefix = f'Purpose: {step_description}. ' if step_description else ''
 
-	# 	if isinstance(step_resolved, NavigationStep):
-	# 		failed_value = f'{description_prefix}Navigate to URL: {step_resolved.url}'
-	# 	elif isinstance(step_resolved, ClickStep):
-	# 		# element_info = step_resolved.elementText or step_resolved.cssSelector
-	# 		# failed_value = f"{description_prefix}Click element: {element_info}"
-	# 		failed_value = f'Find and click element with description: {step_resolved.description}'
-	# 	elif isinstance(step_resolved, InputStep):
-	# 		failed_value = f"{description_prefix}Input text: '{step_resolved.value}' into element."
-	# 	elif isinstance(step_resolved, SelectChangeStep):
-	# 		failed_value = f"{description_prefix}Select option: '{step_resolved.selectedText}' in dropdown."
-	# 	elif isinstance(step_resolved, KeyPressStep):
-	# 		failed_value = f"{description_prefix}Press key: '{step_resolved.key}'"
-	# 	elif isinstance(step_resolved, ScrollStep):
-	# 		failed_value = f'{description_prefix}Scroll to position: (x={step_resolved.scrollX}, y={step_resolved.scrollY})'
-	# 	else:
-	# 		failed_value = f"{description_prefix}No specific target value available for action '{failed_action_name}'"
+		if isinstance(step_resolved, NavigationStep):
+			failed_value = f'{description_prefix}Navigate to URL: {step_resolved.url}'
+		elif isinstance(step_resolved, ClickStep):
+			failed_value = f'Find and click element with description: {step_resolved.description}'
+		elif isinstance(step_resolved, InputStep):
+			failed_value = f"{description_prefix}Input text: '{step_resolved.value}' into element."
+		elif isinstance(step_resolved, SelectChangeStep):
+			failed_value = f"{description_prefix}Select option: '{step_resolved.selectedText}' in dropdown."
+		elif isinstance(step_resolved, KeyPressStep):
+			failed_value = f"{description_prefix}Press key: '{step_resolved.key}'"
+		elif isinstance(step_resolved, ScrollStep):
+			failed_value = f'{description_prefix}Scroll to position: (x={step_resolved.scrollX}, y={step_resolved.scrollY})'
+		else:
+			failed_value = f"{description_prefix}No specific target value available for action '{failed_action_name}'"
 
-	# 	# Build workflow overview using the stored dictionaries
-	# 	workflow_overview_lines: list[str] = []
-	# 	for idx, step in enumerate(self.steps):
-	# 		desc = step.description or ''
-	# 		step_type_info = step.type
-	# 		details = step.model_dump()
-	# 		workflow_overview_lines.append(f'  {idx + 1}. ({step_type_info}) {desc} - {details}')
-	# 	workflow_overview = '\n'.join(workflow_overview_lines)
-	# 	# print(workflow_overview)
+		# Build workflow overview using the stored dictionaries
+		workflow_overview_lines: list[str] = []
+		for idx, step in enumerate(self.schema.steps):
+			desc = step.description or ''
+			step_type_info = step.type
+			details = step.model_dump()
+			workflow_overview_lines.append(f'  {idx + 1}. ({step_type_info}) {desc} - {details}')
+		workflow_overview = '\n'.join(workflow_overview_lines)
 
-	# 	# Build the fallback task with the failed_value
-	# 	fallback_task = WORKFLOW_FALLBACK_PROMPT_TEMPLATE.format(
-	# 		step_index=step_index + 1,
-	# 		total_steps=len(self.steps),
-	# 		workflow_details=workflow_overview,
-	# 		action_type=failed_action_name,
-	# 		fail_details=fail_details,
-	# 		failed_value=failed_value,
-	# 		step_description=step_description,
-	# 	)
-	# 	logger.info(f'Agent fallback task: {fallback_task}')
+		# Build the fallback task with the failed_value
+		fallback_task = WORKFLOW_FALLBACK_PROMPT_TEMPLATE.format(
+			step_index=step_index + 1,
+			total_steps=len(self.schema.steps),
+			workflow_details=workflow_overview,
+			action_type=failed_action_name,
+			fail_details=fail_details,
+			failed_value=failed_value,
+			step_description=step_description,
+		)
+		logger.info(f'Agent fallback task: {fallback_task}')
 
-	# 	# Prepare agent step config based on the failed step, adding task
-	# 	agent_step_config = AgenticWorkflowStep(
-	# 		type='agent',
-	# 		task=fallback_task,
-	# 		max_steps=5,
-	# 		output=None,
-	# 		description='Fallback agent to handle step failure',
-	# 	)
+		# Prepare agent step config based on the failed step, adding task
+		agent_step_config = AgenticWorkflowStep(
+			type='agent',
+			task=fallback_task,
+			max_steps=5,
+			output=None,
+			description='Fallback agent to handle step failure',
+		)
 
-	# 	return await self._run_agent_step(agent_step_config)
+		return await self._run_agent_step(agent_step_config, step_index)
 
 	def _validate_inputs(self, inputs: dict[str, Any]) -> None:
 		"""Validate provided inputs against the workflow's input schema definition."""
@@ -672,7 +678,12 @@ Extracted Information:"""
 						logger.warning(
 							f'Deterministic step {step_index + 1} ({action_name}) failed: {e}. Attempting fallback with agent.'
 						)
-						raise ValueError(f'Deterministic step {step_index + 1} ({action_name}) failed: {e}')
+						if self.fallback_to_agent:
+							result = await self._fallback_to_agent(step_resolved, step_index, e)
+							if not result.is_successful():
+								raise ValueError(f'Deterministic step {step_index + 1} ({action_name}) failed even after fallback')
+						else:
+							raise ValueError(f'Deterministic step {step_index + 1} ({action_name}) failed: {e}')
 			else:
 				# Use deterministic controller execution for all other actions
 				try:
@@ -686,14 +697,12 @@ Extracted Information:"""
 					logger.warning(
 						f'Deterministic step {step_index + 1} ({action_name}) failed: {e}. Attempting fallback with agent.'
 					)
-					raise ValueError(f'Deterministic step {step_index + 1} ({action_name}) failed: {e}')
-
-				# if self.fallback_to_agent:
-				# 	result = await self._fallback_to_agent(step_resolved, step_index, e)
-				# 	if not result.is_successful():
-				# 		raise ValueError(f'Deterministic step {step_index + 1} ({action_name}) failed even after fallback')
-				# else:
-				# 	raise ValueError(f'Deterministic step {step_index + 1} ({action_name}) failed: {e}')
+					if self.fallback_to_agent:
+						result = await self._fallback_to_agent(step_resolved, step_index, e)
+						if not result.is_successful():
+							raise ValueError(f'Deterministic step {step_index + 1} ({action_name}) failed even after fallback')
+					else:
+						raise ValueError(f'Deterministic step {step_index + 1} ({action_name}) failed: {e}')
 
 		elif isinstance(step_resolved, AgenticWorkflowStep):
 			# Use task key from step dictionary


### PR DESCRIPTION
## Summary

I ran `generate-workflow` end-to-end against a real site (an apartment listing site's apply-now flow, with a dismissible popup and a nav-driven multi-page task) using Anthropic models, then replayed the generated workflow. This surfaced three bugs blocking the two features that matter most for this project's value proposition — semantic workflow generation and self-healing replay — plus two smaller bugs in dead code that only appeared once the first fix let it actually run.

- **`workflow_creation_prompt.md`**: an unescaped literal `{variable}` in prose (line 26) broke `prompt_content.format(goal=..., actions=...)` in `HealingService.create_workflow_definition` with `KeyError: 'variable'`, since `str.format()` treats any single-brace token as a substitution placeholder, not just the intentional `{goal}`/`{actions}`. Escaped it to `{{variable}}` to match the rest of the template.

- **`healing/service.py`**: `_history_to_workflow_definition` always tags the agent's screenshot as `image/jpeg` regardless of actual format, so Anthropic rejects it: `messages.1.content.1.image.source.base64: The image was specified using the image/jpeg media type, but the image appears to be a image/png image`. browser-use's `get_screenshot()` returns PNG; fixed the hardcoded MIME type to match.

- **`workflow/service.py`**: `_fallback_to_agent` — the self-healing path — was fully implemented but entirely commented out, so any failed deterministic step (e.g. a selector that no longer matches after a page changes) crashed the whole run instead of healing, even though the surrounding log messages ("Attempting fallback with agent") implied it was active. Re-enabled it, and fixed two bugs in that dead code that only surfaced once it actually executed:
  - `_run_agent_step(agent_step_config)` was missing the required `step_index` argument.
  - `self.steps` doesn't exist on `Workflow` (the attribute is `self.schema.steps`, per the comment a few lines away at `for step_index, step_dict in enumerate(self.schema.steps):  # self.steps now holds dictionaries`).

## Result after all four fixes

Generated a workflow from a live multi-step task (navigate → dismiss popup → click nav → scroll → extract). On replay, two of the five steps' selectors didn't match (expected — they were generated from one page load and matched against a fresh one) and **both healed successfully** through two different paths: the agent-based fallback fixed here handled one, and the existing semantic-executor hierarchical-selector fallback handled the other. The workflow completed end to end with correct extracted data.

## Test plan

- [x] Ran `generate-workflow` against a live site with `ChatAnthropic` as agent/extraction/workflow LLM — completes without the `KeyError` or image MIME error.
- [x] Ran `Workflow.load_from_file(...).run(...)` against the generated workflow — a deterministic step with a stale selector now heals via `_fallback_to_agent` instead of crashing, and the run completes successfully.
- [ ] No existing automated tests were run against this change (couldn't find a test suite covering `workflow/service.py`'s replay path) — happy to add coverage if there's a preferred pattern for it in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four bugs that blocked semantic workflow generation and self-healing replay in end-to-end testing. Failed deterministic steps previously crashed the entire run; they now fall back to the agent and heal.

**Bug Fixes**
- Escaped a literal `{variable}` in `workflow_creation_prompt.md` so `str.format()` no longer raises `KeyError: 'variable'` during workflow generation.
- Uses `image/png` instead of a hardcoded `image/jpeg` MIME type for screenshots, which Anthropic previously rejected as a format mismatch.
- Re-enables `_fallback_to_agent` in `workflow/service.py`, which was fully implemented but commented out.
- Fixes two latent bugs in the fallback path: passes the required `step_index` to `_run_agent_step`, and references `self.schema.steps` instead of the non-existent `self.steps`.

After these fixes, a workflow generated from a live multi-step task replayed end to end with both stale selectors healing successfully via the agent fallback and the existing semantic-executor fallback.

<sup>Written for commit be4620f98af8985ab1d46f0d4c739cad7d946697. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/workflow-use/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

