### PR TITLE
feat: add OrcaRouter as LLM provider for workflow generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ python cli.py generate-workflow "Your task" \
   --extraction-model "gpt-4.1-mini" \
   --workflow-model "gpt-4o"
 
+# Route generation through OrcaRouter's gateway (adaptive routing, failover,
+# observability) using an OpenAI-compatible endpoint
+python cli.py generate-workflow "Your task" \
+  --llm-provider orcarouter \
+  --agent-model "orcarouter/auto" \
+  --extraction-model "orcarouter/auto"
+
 # Use Browser-Use Cloud browser
 python cli.py generate-workflow "Your task" --use-cloud
 

--- a/workflows/.env.example
+++ b/workflows/.env.example
@@ -1,3 +1,6 @@
 # We support all langchain models, openai only for demo purposes
 OPENAI_API_KEY=
 GROQ_API_KEY=
+# Optional: use OrcaRouter as the LLM provider for workflow generation
+# (set --llm-provider orcarouter on `generate-workflow`)
+ORCAROUTER_API_KEY=

--- a/workflows/cli.py
+++ b/workflows/cli.py
@@ -10,7 +10,7 @@ import aiofiles
 import pandas as pd
 import typer
 from browser_use import Browser
-from browser_use.llm import ChatBrowserUse
+from browser_use.llm import ChatBrowserUse, ChatOpenAI
 from browser_use.llm.base import BaseChatModel
 
 from workflow_use.builder.service import BuilderService
@@ -2300,6 +2300,23 @@ def generate_csv_template_command(
 # ==================== GENERATION MODE COMMANDS ====================
 
 
+def _build_generation_llm(model: str, llm_provider: str) -> BaseChatModel:
+	"""Build the LLM used for workflow generation for a given provider.
+
+	``orcarouter`` points an OpenAI-compatible client at OrcaRouter's gateway so
+	its adaptive routing / failover stack is used directly. Any other value keeps
+	the existing browser-use cloud behavior (the ``bu-latest`` alias is resolved
+	by the gateway to the current premium model).
+	"""
+	if llm_provider == 'orcarouter':
+		return ChatOpenAI(
+			model=model,
+			base_url='https://api.orcarouter.ai/v1',
+			api_key=os.getenv('ORCAROUTER_API_KEY'),
+		)
+	return ChatBrowserUse(model='bu-latest')
+
+
 @app.command(name='generate-workflow')
 def generate_workflow_from_task(
 	task: str = typer.Argument(..., help='The task to automate (e.g., "Fill out the contact form")'),
@@ -2309,6 +2326,10 @@ def generate_workflow_from_task(
 	save_to_storage: bool = typer.Option(True, help='Save workflow to storage database'),
 	output_file: Path | None = typer.Option(None, help='Optional: Save to specific file path'),
 	use_cloud: bool = typer.Option(False, help='Use Browser-Use Cloud browser'),
+	llm_provider: str = typer.Option(
+		'browser-use',
+		help='LLM provider for workflow generation: "browser-use" (default) or "orcarouter"',
+	),
 ):
 	"""
 	🤖 GENERATION MODE: Generate a semantic workflow from a task description.
@@ -2331,10 +2352,11 @@ def generate_workflow_from_task(
 	typer.echo()
 
 	# Initialize LLMs
-	agent_llm = ChatBrowserUse(model='bu-latest')
-	extraction_llm = ChatBrowserUse(model='bu-latest')
+	agent_llm = _build_generation_llm(agent_model, llm_provider)
+	extraction_llm = _build_generation_llm(extraction_model, llm_provider)
 
 	typer.echo('Starting browser automation to complete the task...')
+	typer.echo(f'  LLM Provider: {llm_provider}')
 	typer.echo(f'  Agent Model: {agent_model}')
 	typer.echo(f'  Extraction Model: {extraction_model}')
 	typer.echo(f'  Workflow Model: {workflow_model}')


### PR DESCRIPTION
## Summary

Workflow Use's `generate-workflow` command already accepts `--agent-model`/`--extraction-model` options, but those models were never wired up — the agent and extraction LLMs were always built as `ChatBrowserUse(model='bu-latest')`. This PR makes those options effective and adds `--llm-provider`, with `orcarouter` as a first-class provider backed by [OrcaRouter](https://www.orcarouter.ai).

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The implementation mirrors how `browser_use.llm.openai.ChatOpenAI` is already used by the ecosystem: an OpenAI-compatible client pointed at OrcaRouter's `https://api.orcarouter.ai/v1` endpoint with `ORCAROUTER_API_KEY`. The default (`browser-use`) path is unchanged.

### Verification

- `ruff check` and `ruff format --check` pass on `workflows/` (matches CI).
- Live-tested the new `orcarouter` code path against `https://api.orcarouter.ai/v1` with `model=orcarouter/auto` → HTTP 200, completion returned (routed to `gemini-3.1-flash-lite`).

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the `--agent-model` and `--extraction-model` options in `generate-workflow` actually take effect, and adds a new `--llm-provider` option with `orcarouter` as a first-class provider backed by OrcaRouter's OpenAI-compatible gateway.

Previously these model options were ignored; the agent and extraction LLMs were always built with `ChatBrowserUse(model='bu-latest')`. The default `browser-use` path is unchanged.

- The `orcarouter` provider routes workflow generation through OrcaRouter's gateway for adaptive routing and failover.
- Users need to set `ORCAROUTER_API_KEY` in the environment to use the `orcarouter` provider.
- `--agent-model` and `--extraction-model` now apply to the selected provider.

<sup>Written for commit 7bd43bace15f6659e1c62fd8bf7d9f4b6858e32e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/workflow-use/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

