### PR TITLE
Accept Chrome recorder JSON without a trailing extract step

### DIFF
--- a/workflows/tests/test_schema_recording_load.py
+++ b/workflows/tests/test_schema_recording_load.py
@@ -1,0 +1,58 @@
+"""Load Chrome recorder JSON without requiring a trailing extract step."""
+
+from workflow_use.schema.views import ClickStep, WorkflowDefinitionSchema
+
+
+def _chrome_recording_payload(*, last_step_type: str = 'click') -> dict:
+	last_step: dict
+	if last_step_type == 'click':
+		last_step = {
+			'type': 'click',
+			'targetText': 'Order with Careem',
+			'url': 'https://www.ubereats.com/feed',
+		}
+	else:
+		last_step = {'type': 'extract', 'extractionGoal': 'Get confirmation'}
+
+	return {
+		'name': 'Recorded Workflow (Semantic)',
+		'description': 'Recorded on 8/29/2026, 5:50:27 PM',
+		'version': '1.0',
+		'input_schema': [],
+		'steps': [
+			{'type': 'navigation', 'url': 'https://www.ubereats.com/feed'},
+			last_step,
+		],
+	}
+
+
+def test_chrome_recording_ending_in_click_loads():
+	workflow = WorkflowDefinitionSchema.model_validate(_chrome_recording_payload())
+
+	assert len(workflow.steps) == 2
+	assert workflow.steps[-1].type == 'click'
+	assert isinstance(workflow.steps[-1], ClickStep)
+	assert workflow.steps[-1].target_text == 'Order with Careem'
+
+
+def test_snake_case_target_text_still_loads():
+	workflow = WorkflowDefinitionSchema.model_validate(
+		{
+			'name': 'Semantic workflow',
+			'description': 'Hand-written',
+			'version': '1.0',
+			'input_schema': [],
+			'steps': [
+				{'type': 'navigation', 'url': 'https://example.com'},
+				{'type': 'click', 'target_text': 'Submit'},
+			],
+		}
+	)
+
+	assert workflow.steps[-1].target_text == 'Submit'
+
+
+def test_extract_ending_workflow_still_loads():
+	workflow = WorkflowDefinitionSchema.model_validate(_chrome_recording_payload(last_step_type='extract'))
+
+	assert workflow.steps[-1].type == 'extract'

--- a/workflows/workflow_use/schema/views.py
+++ b/workflows/workflow_use/schema/views.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field, validator
+from pydantic import AliasChoices, BaseModel, Field
 
 
 # --- Base Step Model ---
@@ -28,6 +28,8 @@ class BaseWorkflowStep(BaseModel):
 
 # --- Steps that require interaction with a DOM element ---
 class SelectorWorkflowSteps(BaseWorkflowStep):
+	model_config = {'extra': 'allow', 'populate_by_name': True}
+
 	# Legacy fields - kept for backward compatibility but discouraged
 	cssSelector: Optional[str] = Field(
 		None, description='[LEGACY] CSS selector - avoid in new workflows, use target_text instead.'
@@ -43,8 +45,10 @@ class SelectorWorkflowSteps(BaseWorkflowStep):
 	)
 
 	# PRIMARY: Text-based semantic targeting (non-brittle)
+	# Chrome recorder exports `targetText`; semantic replay reads `target_text`.
 	target_text: Optional[str] = Field(
 		None,
+		validation_alias=AliasChoices('target_text', 'targetText'),
 		description='Visible or accessible text to identify the element. Use hierarchical context for disambiguation (e.g., "Submit (in Personal Information)", "Edit (item 2 of 3)"). If None, relies on selectorStrategies fallback.',
 	)
 
@@ -214,7 +218,12 @@ class WorkflowInputSchemaDefinition(BaseModel):
 
 
 class WorkflowDefinitionSchema(BaseModel):
-	"""Pydantic model representing the structure of the workflow JSON file."""
+	"""Pydantic model representing the structure of the workflow JSON file.
+
+	A trailing extract step is recommended for LLM generation (`run-as-tool`) but is
+	not required. Chrome recorder exports often end on click/input and must still load
+	for `run-workflow-no-ai`.
+	"""
 
 	workflow_analysis: Optional[str] = Field(
 		None,
@@ -236,26 +245,6 @@ class WorkflowDefinitionSchema(BaseModel):
 		# default=WorkflowInputSchemaDefinition(),
 		description='List of input schema definitions.',
 	)
-
-	@validator('steps')
-	def validate_ends_with_extract(cls, steps: List[WorkflowStep]) -> List[WorkflowStep]:
-		"""Validate that the workflow ends with an extract step."""
-		if not steps:
-			raise ValueError('Workflow must have at least one step')
-
-		last_step = steps[-1]
-		# Check if last step is an extract step
-		# We need to check the 'type' attribute from the step dict/model
-		step_type = getattr(last_step, 'type', None)
-
-		if step_type not in ['extract', 'extract_page_content']:
-			raise ValueError(
-				f'Workflow must end with an extract step (extract or extract_page_content). '
-				f'Current last step type: {step_type}. '
-				f'AI processing is always needed at the end of a workflow.'
-			)
-
-		return steps
 
 	# Add loader from json file
 	@classmethod


### PR DESCRIPTION
## Summary
- Chrome side-panel Save/Quick Download writes workflows that end on `click`/`input` and use `targetText`. `WorkflowDefinitionSchema` rejected those files, so `run-workflow-no-ai` could not load a recording it just produced.
- Drop the load-time “must end with extract” validator (extract remains the right *generation* convention for `run-as-tool`, not a recorder requirement).
- Accept `targetText` as an alias for `target_text` so semantic replay sees the captured label.

## Test plan
- [x] Load a click-ending Chrome-shaped payload (`targetText`) via `WorkflowDefinitionSchema.model_validate`
- [x] `target_text` snake_case still loads
- [x] Extract-ending workflows still load
- [ ] `python cli.py run-workflow-no-ai path/to/sidepanel-download.json` on a recording that was not manually given an extract step


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loading of Chrome recorder JSON exports so `run-workflow-no-ai` can replay recordings that end on click/input instead of extract. Now accepts `targetText` as an alias for `target_text`.

- Drops the load-time validator that required a trailing extract step; extract remains the recommended generation convention for `run-as-tool`.

<sup>Written for commit 5fdae8b4d19acca03da893807a2c9b457c322e04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/workflow-use/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

